### PR TITLE
refactor(charts): eliminate duplication via Strategy/Factory pattern

### DIFF
--- a/packages/charts/src/domain/abs-churn-chart.visual.ts
+++ b/packages/charts/src/domain/abs-churn-chart.visual.ts
@@ -1,12 +1,8 @@
 import type { AbsChurn } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapAbsChurnToLineArea } from "../mappers/churn.mapper";
-import type { ThemePreset } from "../types";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/line-area.visual";
-
-type AbsChurnVariant = "area" | "line";
 
 /**
  * Absolute churn chart showing added/deleted lines over time.
@@ -24,36 +20,29 @@ type AbsChurnVariant = "area" | "line";
  * <pq-abs-churn-chart src="/api/analysis/abs-churn" theme="dark" variant="area"></pq-abs-churn-chart>
  * ```
  */
-@customElement("pq-abs-churn-chart")
-export class PqAbsChurnChart extends LitElement {
-  private fetcher = new DataFetchController<AbsChurn>(this);
-
-  @property({ type: Array }) data?: AbsChurn[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property() variant: AbsChurnVariant = "area";
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): AbsChurn[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    return html`<pq-line-area
-      .data=${mapAbsChurnToLineArea(this.resolvedData)}
-      .theme=${this.theme}
-      .fill=${this.variant === "area"}
-      show-legend
-    ></pq-line-area>`;
-  }
-}
+export const PqAbsChurnChart = defineDomainChart<AbsChurn>({
+  tag: "pq-abs-churn-chart",
+  defaultVariant: "area",
+  variants: {
+    area: (data, theme) =>
+      html`<pq-line-area
+        .data=${mapAbsChurnToLineArea(data)}
+        .theme=${theme}
+        .fill=${true}
+        show-legend
+      ></pq-line-area>`,
+    line: (data, theme) =>
+      html`<pq-line-area
+        .data=${mapAbsChurnToLineArea(data)}
+        .theme=${theme}
+        .fill=${false}
+        show-legend
+      ></pq-line-area>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-abs-churn-chart": PqAbsChurnChart;
+    "pq-abs-churn-chart": InstanceType<typeof PqAbsChurnChart>;
   }
 }

--- a/packages/charts/src/domain/age-chart.visual.ts
+++ b/packages/charts/src/domain/age-chart.visual.ts
@@ -1,13 +1,9 @@
 import type { CodeAge } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapAgeToBar, mapAgeToHistogram } from "../mappers/age.mapper";
-import type { ThemePreset } from "../types";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/histogram.visual";
 import "../generic/ranked-bar.visual";
-
-type AgeVariant = "histogram" | "bar";
 
 /**
  * Code age chart showing file age distribution as histogram or ranked bar.
@@ -25,48 +21,33 @@ type AgeVariant = "histogram" | "bar";
  * <pq-age-chart src="/api/analysis/age" variant="histogram" bins="8"></pq-age-chart>
  * ```
  */
-@customElement("pq-age-chart")
-export class PqAgeChart extends LitElement {
-  private fetcher = new DataFetchController<CodeAge>(this);
-
-  @property({ type: Array }) data?: CodeAge[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property() variant: AgeVariant = "histogram";
-  @property({ type: Number }) limit = 20;
-  @property({ type: Number }) bins = 10;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): CodeAge[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    if (this.variant === "bar") {
-      return html`<pq-ranked-bar
-        .data=${mapAgeToBar(this.resolvedData)}
-        .limit=${this.limit}
-        .theme=${this.theme}
+export const PqAgeChart = defineDomainChart<CodeAge, { bins: number }>({
+  tag: "pq-age-chart",
+  defaultVariant: "histogram",
+  properties: { bins: { type: Number } },
+  defaults: { bins: 10 },
+  variants: {
+    histogram: (data, theme, _limit, extra) =>
+      html`<pq-histogram
+        .data=${mapAgeToHistogram(data).map((v) => ({ value: v }))}
+        .bins=${extra?.bins ?? 10}
+        .theme=${theme}
+        x-label="Age (months)"
+        y-label="Files"
+      ></pq-histogram>`,
+    bar: (data, theme, limit) =>
+      html`<pq-ranked-bar
+        .data=${mapAgeToBar(data)}
+        .limit=${limit}
+        .theme=${theme}
         sort="desc"
         horizontal
-      ></pq-ranked-bar>`;
-    }
-    return html`<pq-histogram
-      .data=${mapAgeToHistogram(this.resolvedData).map((v) => ({ value: v }))}
-      .bins=${this.bins}
-      .theme=${this.theme}
-      x-label="Age (months)"
-      y-label="Files"
-    ></pq-histogram>`;
-  }
-}
+      ></pq-ranked-bar>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-age-chart": PqAgeChart;
+    "pq-age-chart": InstanceType<typeof PqAgeChart>;
   }
 }

--- a/packages/charts/src/domain/author-churn-chart.visual.ts
+++ b/packages/charts/src/domain/author-churn-chart.visual.ts
@@ -1,13 +1,9 @@
 import type { AuthorChurn } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapAuthorChurnToGrouped, mapAuthorChurnToStacked } from "../mappers/churn.mapper";
-import type { ThemePreset } from "../types";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/grouped-bar.visual";
 import "../generic/stacked-bar.visual";
-
-type AuthorChurnVariant = "grouped" | "stacked";
 
 /**
  * Author churn chart showing added/deleted/commits per author.
@@ -23,40 +19,19 @@ type AuthorChurnVariant = "grouped" | "stacked";
  * <pq-author-churn-chart src="/api/analysis/author-churn" variant="grouped"></pq-author-churn-chart>
  * ```
  */
-@customElement("pq-author-churn-chart")
-export class PqAuthorChurnChart extends LitElement {
-  private fetcher = new DataFetchController<AuthorChurn>(this);
-
-  @property({ type: Array }) data?: AuthorChurn[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property() variant: AuthorChurnVariant = "grouped";
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): AuthorChurn[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    if (this.variant === "stacked") {
-      return html`<pq-stacked-bar
-        .data=${mapAuthorChurnToStacked(this.resolvedData)}
-        .theme=${this.theme}
-      ></pq-stacked-bar>`;
-    }
-    return html`<pq-grouped-bar
-      .data=${mapAuthorChurnToGrouped(this.resolvedData)}
-      .theme=${this.theme}
-    ></pq-grouped-bar>`;
-  }
-}
+export const PqAuthorChurnChart = defineDomainChart<AuthorChurn>({
+  tag: "pq-author-churn-chart",
+  defaultVariant: "grouped",
+  variants: {
+    grouped: (data, theme) =>
+      html`<pq-grouped-bar .data=${mapAuthorChurnToGrouped(data)} .theme=${theme}></pq-grouped-bar>`,
+    stacked: (data, theme) =>
+      html`<pq-stacked-bar .data=${mapAuthorChurnToStacked(data)} .theme=${theme}></pq-stacked-bar>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-author-churn-chart": PqAuthorChurnChart;
+    "pq-author-churn-chart": InstanceType<typeof PqAuthorChurnChart>;
   }
 }

--- a/packages/charts/src/domain/authors-chart.visual.ts
+++ b/packages/charts/src/domain/authors-chart.visual.ts
@@ -1,13 +1,9 @@
 import type { Author } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapAuthorsToBar, mapAuthorsToTreemap } from "../mappers/authors.mapper";
-import type { ThemePreset } from "../types";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/ranked-bar.visual";
 import "../generic/treemap.visual";
-
-type AuthorsVariant = "bar" | "treemap";
 
 /**
  * Authors chart showing author count per entity as bar or treemap.
@@ -24,45 +20,25 @@ type AuthorsVariant = "bar" | "treemap";
  * <pq-authors-chart src="/api/analysis/authors" variant="bar" limit="15"></pq-authors-chart>
  * ```
  */
-@customElement("pq-authors-chart")
-export class PqAuthorsChart extends LitElement {
-  private fetcher = new DataFetchController<Author>(this);
-
-  @property({ type: Array }) data?: Author[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property() variant: AuthorsVariant = "bar";
-  @property({ type: Number }) limit = 20;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): Author[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    if (this.variant === "treemap") {
-      return html`<pq-treemap
-        .data=${mapAuthorsToTreemap(this.resolvedData)}
-        .theme=${this.theme}
-        show-labels
-      ></pq-treemap>`;
-    }
-    return html`<pq-ranked-bar
-      .data=${mapAuthorsToBar(this.resolvedData)}
-      .limit=${this.limit}
-      .theme=${this.theme}
-      sort="desc"
-      horizontal
-    ></pq-ranked-bar>`;
-  }
-}
+export const PqAuthorsChart = defineDomainChart<Author>({
+  tag: "pq-authors-chart",
+  defaultVariant: "bar",
+  variants: {
+    bar: (data, theme, limit) =>
+      html`<pq-ranked-bar
+        .data=${mapAuthorsToBar(data)}
+        .limit=${limit}
+        .theme=${theme}
+        sort="desc"
+        horizontal
+      ></pq-ranked-bar>`,
+    treemap: (data, theme) =>
+      html`<pq-treemap .data=${mapAuthorsToTreemap(data)} .theme=${theme} show-labels></pq-treemap>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-authors-chart": PqAuthorsChart;
+    "pq-authors-chart": InstanceType<typeof PqAuthorsChart>;
   }
 }

--- a/packages/charts/src/domain/communication-chart.visual.ts
+++ b/packages/charts/src/domain/communication-chart.visual.ts
@@ -1,13 +1,9 @@
 import type { Communication } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapCommunicationToBar, mapCommunicationToBubble } from "../mappers/communication.mapper";
-import type { ThemePreset } from "../types";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/bubble.visual";
 import "../generic/ranked-bar.visual";
-
-type CommunicationVariant = "bubble" | "bar";
 
 /**
  * Communication chart showing author-peer collaboration as bubble or bar.
@@ -24,44 +20,25 @@ type CommunicationVariant = "bubble" | "bar";
  * <pq-communication-chart src="/api/analysis/communication" variant="bubble"></pq-communication-chart>
  * ```
  */
-@customElement("pq-communication-chart")
-export class PqCommunicationChart extends LitElement {
-  private fetcher = new DataFetchController<Communication>(this);
-
-  @property({ type: Array }) data?: Communication[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property() variant: CommunicationVariant = "bubble";
-  @property({ type: Number }) limit = 20;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): Communication[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    if (this.variant === "bar") {
-      return html`<pq-ranked-bar
-        .data=${mapCommunicationToBar(this.resolvedData)}
-        .limit=${this.limit}
-        .theme=${this.theme}
+export const PqCommunicationChart = defineDomainChart<Communication>({
+  tag: "pq-communication-chart",
+  defaultVariant: "bubble",
+  variants: {
+    bar: (data, theme, limit) =>
+      html`<pq-ranked-bar
+        .data=${mapCommunicationToBar(data)}
+        .limit=${limit}
+        .theme=${theme}
         sort="desc"
         horizontal
-      ></pq-ranked-bar>`;
-    }
-    return html`<pq-bubble
-      .data=${mapCommunicationToBubble(this.resolvedData)}
-      .theme=${this.theme}
-    ></pq-bubble>`;
-  }
-}
+      ></pq-ranked-bar>`,
+    bubble: (data, theme) =>
+      html`<pq-bubble .data=${mapCommunicationToBubble(data)} .theme=${theme}></pq-bubble>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-communication-chart": PqCommunicationChart;
+    "pq-communication-chart": InstanceType<typeof PqCommunicationChart>;
   }
 }

--- a/packages/charts/src/domain/coupling-chart.visual.ts
+++ b/packages/charts/src/domain/coupling-chart.visual.ts
@@ -1,13 +1,9 @@
 import type { Coupling } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapCouplingToBar, mapCouplingToBubble } from "../mappers/coupling.mapper";
-import type { ThemePreset } from "../types";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/bubble.visual";
 import "../generic/ranked-bar.visual";
-
-type CouplingVariant = "bubble" | "bar";
 
 /**
  * Coupling chart showing temporal coupling between entities as bubble or bar.
@@ -24,44 +20,25 @@ type CouplingVariant = "bubble" | "bar";
  * <pq-coupling-chart src="/api/analysis/coupling" variant="bubble"></pq-coupling-chart>
  * ```
  */
-@customElement("pq-coupling-chart")
-export class PqCouplingChart extends LitElement {
-  private fetcher = new DataFetchController<Coupling>(this);
-
-  @property({ type: Array }) data?: Coupling[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property() variant: CouplingVariant = "bubble";
-  @property({ type: Number }) limit = 20;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): Coupling[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    if (this.variant === "bar") {
-      return html`<pq-ranked-bar
-        .data=${mapCouplingToBar(this.resolvedData)}
-        .limit=${this.limit}
-        .theme=${this.theme}
+export const PqCouplingChart = defineDomainChart<Coupling>({
+  tag: "pq-coupling-chart",
+  defaultVariant: "bubble",
+  variants: {
+    bar: (data, theme, limit) =>
+      html`<pq-ranked-bar
+        .data=${mapCouplingToBar(data)}
+        .limit=${limit}
+        .theme=${theme}
         sort="desc"
         horizontal
-      ></pq-ranked-bar>`;
-    }
-    return html`<pq-bubble
-      .data=${mapCouplingToBubble(this.resolvedData)}
-      .theme=${this.theme}
-    ></pq-bubble>`;
-  }
-}
+      ></pq-ranked-bar>`,
+    bubble: (data, theme) =>
+      html`<pq-bubble .data=${mapCouplingToBubble(data)} .theme=${theme}></pq-bubble>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-coupling-chart": PqCouplingChart;
+    "pq-coupling-chart": InstanceType<typeof PqCouplingChart>;
   }
 }

--- a/packages/charts/src/domain/define-domain-chart.ts
+++ b/packages/charts/src/domain/define-domain-chart.ts
@@ -172,7 +172,7 @@ export function defineDomainChart<T, P extends Record<string, unknown> = Record<
   config: DomainChartConfig<T, P>,
 ): typeof LitElement {
   class DomainChart extends LitElement {
-    static override properties = {
+    static override readonly properties = {
       data: { type: Array },
       src: {},
       theme: {},
@@ -181,7 +181,7 @@ export function defineDomainChart<T, P extends Record<string, unknown> = Record<
       ...config.properties,
     };
 
-    private fetcher = new DataFetchController<T>(this);
+    private readonly fetcher = new DataFetchController<T>(this);
 
     data?: T[];
     src?: string;

--- a/packages/charts/src/domain/define-domain-chart.ts
+++ b/packages/charts/src/domain/define-domain-chart.ts
@@ -218,6 +218,8 @@ export function defineDomainChart<T, P extends Record<string, unknown> = Record<
     }
   }
 
-  customElements.define(config.tag, DomainChart);
+  if (!customElements.get(config.tag)) {
+    customElements.define(config.tag, DomainChart);
+  }
   return DomainChart;
 }

--- a/packages/charts/src/domain/define-domain-chart.ts
+++ b/packages/charts/src/domain/define-domain-chart.ts
@@ -1,0 +1,134 @@
+import type { TemplateResult } from "lit";
+import { LitElement } from "lit";
+import { DataFetchController } from "../controllers/data-fetch.controller";
+import type { ThemePreset } from "../types";
+
+/**
+ * Strategy function that renders a specific chart variant from domain data.
+ *
+ * Receives the resolved data array, the current theme preset, and the
+ * configured item limit. Returns a Lit `TemplateResult` delegating to
+ * the appropriate generic chart component.
+ *
+ * @typeParam T - The domain data item type this variant renders.
+ * @param data - Resolved non-empty data array (inline prop or fetched).
+ * @param theme - Current theme preset (may be undefined).
+ * @param limit - Maximum number of items to display (default `20`).
+ * @returns A Lit `TemplateResult` wrapping the target generic chart.
+ *
+ * @example
+ * ```ts
+ * const barRenderer: VariantRenderer<Revision> = (data, theme, limit) =>
+ *   html`<pq-ranked-bar .data=${mapRevisionsToBar(data)} .limit=${limit} .theme=${theme}></pq-ranked-bar>`;
+ * ```
+ */
+export type VariantRenderer<T> = (data: T[], theme?: ThemePreset, limit?: number) => TemplateResult;
+
+/**
+ * Configuration object passed to {@link defineDomainChart}.
+ *
+ * @typeParam T - The domain data item type this chart renders.
+ *
+ * @example
+ * ```ts
+ * const config: DomainChartConfig<Revision> = {
+ *   tag: "pq-revisions-chart",
+ *   defaultVariant: "bar",
+ *   variants: {
+ *     bar: (data, theme, limit) => html`<pq-ranked-bar .data=${mapRevisionsToBar(data)} .limit=${limit} .theme=${theme} sort="desc" horizontal></pq-ranked-bar>`,
+ *     treemap: (data, theme) => html`<pq-treemap .data=${mapRevisionsToTreemap(data)} .theme=${theme} show-labels></pq-treemap>`,
+ *   },
+ * };
+ * ```
+ */
+export type DomainChartConfig<T> = {
+  /**
+   * Custom element tag name (e.g. `"pq-revisions-chart"`).
+   * Must be a valid custom element name (hyphenated, lowercase).
+   */
+  tag: string;
+
+  /**
+   * The variant key to use when no `variant` attribute is provided.
+   * Must match one of the keys in `variants`.
+   */
+  defaultVariant: string;
+
+  /**
+   * Map of variant name to renderer function.
+   * Each renderer receives the resolved data, current theme, and limit,
+   * and returns a Lit `TemplateResult` delegating to a generic chart component.
+   */
+  variants: Record<string, VariantRenderer<T>>;
+
+  /**
+   * Default maximum number of items to show in ranked/bar variants.
+   * Defaults to `20` when omitted.
+   */
+  limit?: number;
+};
+
+/**
+ * Factory that creates and registers a domain-specific Lit Web Component.
+ *
+ * All shared infrastructure (`DataFetchController`, base properties, lifecycle,
+ * `resolvedData` getter) is handled by the factory. Consumers supply only
+ * the data type, available variants (as renderer functions), and the default variant.
+ *
+ * No class inheritance. No abstract methods. Composition only.
+ *
+ * @typeParam T - The domain data item type this chart renders.
+ * @param config - Component configuration: tag, defaultVariant, variants map, optional limit.
+ * @returns The generated Lit element class (use for `HTMLElementTagNameMap` augmentation).
+ *
+ * @example
+ * ```ts
+ * export const PqRevisionsChart = defineDomainChart<Revision>({
+ *   tag: "pq-revisions-chart",
+ *   defaultVariant: "bar",
+ *   variants: {
+ *     bar: (data, theme, limit) =>
+ *       html`<pq-ranked-bar .data=${mapRevisionsToBar(data)} .limit=${limit} .theme=${theme} sort="desc" horizontal></pq-ranked-bar>`,
+ *     treemap: (data, theme) =>
+ *       html`<pq-treemap .data=${mapRevisionsToTreemap(data)} .theme=${theme} show-labels></pq-treemap>`,
+ *   },
+ * });
+ * ```
+ */
+export function defineDomainChart<T>(config: DomainChartConfig<T>): typeof LitElement {
+  class DomainChart extends LitElement {
+    static override properties = {
+      data: { type: Array },
+      src: {},
+      theme: {},
+      variant: {},
+      limit: { type: Number },
+    };
+
+    private fetcher = new DataFetchController<T>(this);
+
+    data?: T[];
+    src?: string;
+    theme?: ThemePreset;
+    variant: string = config.defaultVariant;
+    limit: number = config.limit ?? 20;
+
+    protected override async updated(changed: Map<string, unknown>): Promise<void> {
+      if (changed.has("src") || changed.has("data"))
+        await this.fetcher.fetch(this.src ?? "", !!this.data);
+    }
+
+    private get resolvedData(): T[] {
+      return this.data ?? this.fetcher.data ?? [];
+    }
+
+    protected override render(): TemplateResult | undefined {
+      const renderer = config.variants[this.variant];
+      if (!renderer) return undefined;
+      return renderer(this.resolvedData, this.theme, this.limit);
+    }
+  }
+
+  customElements.define(config.tag, DomainChart);
+  return DomainChart;
+}

--- a/packages/charts/src/domain/define-domain-chart.ts
+++ b/packages/charts/src/domain/define-domain-chart.ts
@@ -6,14 +6,19 @@ import type { ThemePreset } from "../types";
 /**
  * Strategy function that renders a specific chart variant from domain data.
  *
- * Receives the resolved data array, the current theme preset, and the
- * configured item limit. Returns a Lit `TemplateResult` delegating to
- * the appropriate generic chart component.
+ * Receives the resolved data array, the current theme preset, the
+ * configured item limit, and any extra consumer-declared properties.
+ * Returns a Lit `TemplateResult` delegating to the appropriate generic chart component.
+ *
+ * The 4th parameter `extra` is required in the type signature but TypeScript
+ * callback compatibility means existing 3-param renderers remain assignable.
  *
  * @typeParam T - The domain data item type this variant renders.
+ * @typeParam P - Record of extra consumer-declared properties.
  * @param data - Resolved non-empty data array (inline prop or fetched).
  * @param theme - Current theme preset (may be undefined).
  * @param limit - Maximum number of items to display (default `20`).
+ * @param extra - Current values of all extra consumer-declared properties.
  * @returns A Lit `TemplateResult` wrapping the target generic chart.
  *
  * @example
@@ -21,13 +26,25 @@ import type { ThemePreset } from "../types";
  * const barRenderer: VariantRenderer<Revision> = (data, theme, limit) =>
  *   html`<pq-ranked-bar .data=${mapRevisionsToBar(data)} .limit=${limit} .theme=${theme}></pq-ranked-bar>`;
  * ```
+ *
+ * @example
+ * ```ts
+ * const histRenderer: VariantRenderer<CodeAge, { bins: number }> = (data, theme, limit, { bins }) =>
+ *   html`<pq-histogram .data=${mapAgeToHistogram(data).map(v => ({ value: v }))} .bins=${bins} .theme=${theme}></pq-histogram>`;
+ * ```
  */
-export type VariantRenderer<T> = (data: T[], theme?: ThemePreset, limit?: number) => TemplateResult;
+export type VariantRenderer<T, P extends Record<string, unknown> = Record<string, never>> = (
+  data: T[],
+  theme?: ThemePreset,
+  limit?: number,
+  extra?: P,
+) => TemplateResult;
 
 /**
  * Configuration object passed to {@link defineDomainChart}.
  *
  * @typeParam T - The domain data item type this chart renders.
+ * @typeParam P - Record of extra consumer-declared properties (e.g. `{ bins: number }`).
  *
  * @example
  * ```ts
@@ -40,8 +57,22 @@ export type VariantRenderer<T> = (data: T[], theme?: ThemePreset, limit?: number
  *   },
  * };
  * ```
+ *
+ * @example
+ * ```ts
+ * const config: DomainChartConfig<CodeAge, { bins: number }> = {
+ *   tag: "pq-age-chart",
+ *   defaultVariant: "histogram",
+ *   properties: { bins: { type: Number } },
+ *   defaults: { bins: 10 },
+ *   variants: {
+ *     histogram: (data, theme, limit, { bins }) =>
+ *       html`<pq-histogram .data=${mapAgeToHistogram(data).map(v => ({ value: v }))} .bins=${bins} .theme=${theme}></pq-histogram>`,
+ *   },
+ * };
+ * ```
  */
-export type DomainChartConfig<T> = {
+export type DomainChartConfig<T, P extends Record<string, unknown> = Record<string, never>> = {
   /**
    * Custom element tag name (e.g. `"pq-revisions-chart"`).
    * Must be a valid custom element name (hyphenated, lowercase).
@@ -56,16 +87,39 @@ export type DomainChartConfig<T> = {
 
   /**
    * Map of variant name to renderer function.
-   * Each renderer receives the resolved data, current theme, and limit,
+   * Each renderer receives the resolved data, current theme, limit, and extra props,
    * and returns a Lit `TemplateResult` delegating to a generic chart component.
    */
-  variants: Record<string, VariantRenderer<T>>;
+  variants: Record<string, VariantRenderer<T, P>>;
 
   /**
    * Default maximum number of items to show in ranked/bar variants.
    * Defaults to `20` when omitted.
    */
   limit?: number;
+
+  /**
+   * Extra consumer-declared reactive properties, declared using Lit's `static properties` map format.
+   * Do NOT include `data`, `src`, `theme`, `variant`, or `limit` — these are injected by the factory.
+   *
+   * @example
+   * ```ts
+   * properties: { bins: { type: Number } }
+   * ```
+   */
+  properties?: Record<string, unknown>;
+
+  /**
+   * Default values for each extra consumer-declared property.
+   * Every key in `properties` SHOULD have a corresponding default here.
+   * These values are set on the instance during construction.
+   *
+   * @example
+   * ```ts
+   * defaults: { bins: 10 }
+   * ```
+   */
+  defaults?: P;
 };
 
 /**
@@ -73,12 +127,17 @@ export type DomainChartConfig<T> = {
  *
  * All shared infrastructure (`DataFetchController`, base properties, lifecycle,
  * `resolvedData` getter) is handled by the factory. Consumers supply only
- * the data type, available variants (as renderer functions), and the default variant.
+ * the data type, available variants (as renderer functions), the default variant,
+ * and any extra consumer-declared properties.
  *
  * No class inheritance. No abstract methods. Composition only.
  *
+ * **Backward compatible**: existing calls to `defineDomainChart<T>()` with no
+ * second type parameter continue to work without any changes.
+ *
  * @typeParam T - The domain data item type this chart renders.
- * @param config - Component configuration: tag, defaultVariant, variants map, optional limit.
+ * @typeParam P - Record of extra consumer-declared properties (default: `Record<string, never>`).
+ * @param config - Component configuration: tag, defaultVariant, variants map, optional limit, optional properties/defaults.
  * @returns The generated Lit element class (use for `HTMLElementTagNameMap` augmentation).
  *
  * @example
@@ -94,8 +153,24 @@ export type DomainChartConfig<T> = {
  *   },
  * });
  * ```
+ *
+ * @example
+ * ```ts
+ * export const PqAgeChart = defineDomainChart<CodeAge, { bins: number }>({
+ *   tag: "pq-age-chart",
+ *   defaultVariant: "histogram",
+ *   properties: { bins: { type: Number } },
+ *   defaults: { bins: 10 },
+ *   variants: {
+ *     histogram: (data, theme, limit, { bins }) =>
+ *       html`<pq-histogram .data=${mapAgeToHistogram(data).map(v => ({ value: v }))} .bins=${bins} .theme=${theme}></pq-histogram>`,
+ *   },
+ * });
+ * ```
  */
-export function defineDomainChart<T>(config: DomainChartConfig<T>): typeof LitElement {
+export function defineDomainChart<T, P extends Record<string, unknown> = Record<string, never>>(
+  config: DomainChartConfig<T, P>,
+): typeof LitElement {
   class DomainChart extends LitElement {
     static override properties = {
       data: { type: Array },
@@ -103,6 +178,7 @@ export function defineDomainChart<T>(config: DomainChartConfig<T>): typeof LitEl
       theme: {},
       variant: {},
       limit: { type: Number },
+      ...config.properties,
     };
 
     private fetcher = new DataFetchController<T>(this);
@@ -112,6 +188,13 @@ export function defineDomainChart<T>(config: DomainChartConfig<T>): typeof LitEl
     theme?: ThemePreset;
     variant: string = config.defaultVariant;
     limit: number = config.limit ?? 20;
+
+    constructor() {
+      super();
+      for (const [key, value] of Object.entries(config.defaults ?? {})) {
+        (this as unknown as Record<string, unknown>)[key] = value;
+      }
+    }
 
     protected override async updated(changed: Map<string, unknown>): Promise<void> {
       if (changed.has("src") || changed.has("data"))
@@ -125,7 +208,13 @@ export function defineDomainChart<T>(config: DomainChartConfig<T>): typeof LitEl
     protected override render(): TemplateResult | undefined {
       const renderer = config.variants[this.variant];
       if (!renderer) return undefined;
-      return renderer(this.resolvedData, this.theme, this.limit);
+
+      const extra = {} as P;
+      for (const key of Object.keys(config.defaults ?? {})) {
+        (extra as Record<string, unknown>)[key] = (this as unknown as Record<string, unknown>)[key];
+      }
+
+      return renderer(this.resolvedData, this.theme, this.limit, extra);
     }
   }
 

--- a/packages/charts/src/domain/effort-chart.visual.ts
+++ b/packages/charts/src/domain/effort-chart.visual.ts
@@ -1,13 +1,9 @@
 import type { EntityEffort } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapEffortToDoughnut, mapEffortToStacked } from "../mappers/effort.mapper";
-import type { ThemePreset } from "../types";
-import "../generic/stacked-bar.visual";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/doughnut.visual";
-
-type EffortVariant = "stacked" | "doughnut";
+import "../generic/stacked-bar.visual";
 
 /**
  * Effort chart showing author contributions per entity as stacked bar or doughnut.
@@ -24,41 +20,24 @@ type EffortVariant = "stacked" | "doughnut";
  * <pq-effort-chart src="/api/analysis/effort" variant="stacked"></pq-effort-chart>
  * ```
  */
-@customElement("pq-effort-chart")
-export class PqEffortChart extends LitElement {
-  private fetcher = new DataFetchController<EntityEffort>(this);
-
-  @property({ type: Array }) data?: EntityEffort[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property() variant: EffortVariant = "stacked";
-  @property() entity = "";
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): EntityEffort[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    if (this.variant === "doughnut") {
-      return html`<pq-doughnut
-        .data=${mapEffortToDoughnut(this.resolvedData, this.entity)}
-        .theme=${this.theme}
-      ></pq-doughnut>`;
-    }
-    return html`<pq-stacked-bar
-      .data=${mapEffortToStacked(this.resolvedData)}
-      .theme=${this.theme}
-    ></pq-stacked-bar>`;
-  }
-}
+export const PqEffortChart = defineDomainChart<EntityEffort, { entity: string }>({
+  tag: "pq-effort-chart",
+  defaultVariant: "stacked",
+  properties: { entity: {} },
+  defaults: { entity: "" },
+  variants: {
+    doughnut: (data, theme, _limit, extra) =>
+      html`<pq-doughnut
+        .data=${mapEffortToDoughnut(data, extra?.entity ?? "")}
+        .theme=${theme}
+      ></pq-doughnut>`,
+    stacked: (data, theme) =>
+      html`<pq-stacked-bar .data=${mapEffortToStacked(data)} .theme=${theme}></pq-stacked-bar>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-effort-chart": PqEffortChart;
+    "pq-effort-chart": InstanceType<typeof PqEffortChart>;
   }
 }

--- a/packages/charts/src/domain/entity-churn-chart.visual.ts
+++ b/packages/charts/src/domain/entity-churn-chart.visual.ts
@@ -1,13 +1,9 @@
 import type { EntityChurn } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapEntityChurnToGrouped, mapEntityChurnToStacked } from "../mappers/churn.mapper";
-import type { ThemePreset } from "../types";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/grouped-bar.visual";
 import "../generic/stacked-bar.visual";
-
-type EntityChurnVariant = "grouped" | "stacked";
 
 /**
  * Entity churn chart showing added/deleted/commits per entity.
@@ -23,40 +19,19 @@ type EntityChurnVariant = "grouped" | "stacked";
  * <pq-entity-churn-chart src="/api/analysis/entity-churn" variant="stacked"></pq-entity-churn-chart>
  * ```
  */
-@customElement("pq-entity-churn-chart")
-export class PqEntityChurnChart extends LitElement {
-  private fetcher = new DataFetchController<EntityChurn>(this);
-
-  @property({ type: Array }) data?: EntityChurn[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property() variant: EntityChurnVariant = "grouped";
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): EntityChurn[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    if (this.variant === "stacked") {
-      return html`<pq-stacked-bar
-        .data=${mapEntityChurnToStacked(this.resolvedData)}
-        .theme=${this.theme}
-      ></pq-stacked-bar>`;
-    }
-    return html`<pq-grouped-bar
-      .data=${mapEntityChurnToGrouped(this.resolvedData)}
-      .theme=${this.theme}
-    ></pq-grouped-bar>`;
-  }
-}
+export const PqEntityChurnChart = defineDomainChart<EntityChurn>({
+  tag: "pq-entity-churn-chart",
+  defaultVariant: "grouped",
+  variants: {
+    grouped: (data, theme) =>
+      html`<pq-grouped-bar .data=${mapEntityChurnToGrouped(data)} .theme=${theme}></pq-grouped-bar>`,
+    stacked: (data, theme) =>
+      html`<pq-stacked-bar .data=${mapEntityChurnToStacked(data)} .theme=${theme}></pq-stacked-bar>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-entity-churn-chart": PqEntityChurnChart;
+    "pq-entity-churn-chart": InstanceType<typeof PqEntityChurnChart>;
   }
 }

--- a/packages/charts/src/domain/fragmentation-chart.visual.ts
+++ b/packages/charts/src/domain/fragmentation-chart.visual.ts
@@ -1,13 +1,9 @@
 import type { Fragmentation } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapFragmentationToBar, mapFragmentationToDoughnut } from "../mappers/fragmentation.mapper";
-import type { ThemePreset } from "../types";
-import "../generic/ranked-bar.visual";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/doughnut.visual";
-
-type FragmentationVariant = "bar" | "doughnut";
+import "../generic/ranked-bar.visual";
 
 /**
  * Fragmentation chart showing knowledge fragmentation (fractal value) as bar or doughnut.
@@ -24,44 +20,25 @@ type FragmentationVariant = "bar" | "doughnut";
  * <pq-fragmentation-chart src="/api/analysis/fragmentation" variant="bar" limit="15"></pq-fragmentation-chart>
  * ```
  */
-@customElement("pq-fragmentation-chart")
-export class PqFragmentationChart extends LitElement {
-  private fetcher = new DataFetchController<Fragmentation>(this);
-
-  @property({ type: Array }) data?: Fragmentation[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property() variant: FragmentationVariant = "bar";
-  @property({ type: Number }) limit = 20;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): Fragmentation[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    if (this.variant === "doughnut") {
-      return html`<pq-doughnut
-        .data=${mapFragmentationToDoughnut(this.resolvedData)}
-        .theme=${this.theme}
-      ></pq-doughnut>`;
-    }
-    return html`<pq-ranked-bar
-      .data=${mapFragmentationToBar(this.resolvedData)}
-      .limit=${this.limit}
-      .theme=${this.theme}
-      sort="desc"
-      horizontal
-    ></pq-ranked-bar>`;
-  }
-}
+export const PqFragmentationChart = defineDomainChart<Fragmentation>({
+  tag: "pq-fragmentation-chart",
+  defaultVariant: "bar",
+  variants: {
+    bar: (data, theme, limit) =>
+      html`<pq-ranked-bar
+        .data=${mapFragmentationToBar(data)}
+        .limit=${limit}
+        .theme=${theme}
+        sort="desc"
+        horizontal
+      ></pq-ranked-bar>`,
+    doughnut: (data, theme) =>
+      html`<pq-doughnut .data=${mapFragmentationToDoughnut(data)} .theme=${theme}></pq-doughnut>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-fragmentation-chart": PqFragmentationChart;
+    "pq-fragmentation-chart": InstanceType<typeof PqFragmentationChart>;
   }
 }

--- a/packages/charts/src/domain/hotspots-chart.visual.ts
+++ b/packages/charts/src/domain/hotspots-chart.visual.ts
@@ -1,15 +1,11 @@
 import type { ComplexityHotspot } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapHotspotsToBubble, mapHotspotsToTreemap } from "../mappers/hotspots.mapper";
 import { mapHotspotsToEnclosure } from "../mappers/hotspots-enclosure.mapper";
-import type { ThemePreset } from "../types";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/bubble.visual";
-import "../generic/treemap.visual";
 import "../generic/enclosure.visual";
-
-type HotspotsVariant = "bubble" | "treemap" | "enclosure";
+import "../generic/treemap.visual";
 
 /**
  * Complexity hotspots chart as bubble, treemap, or zoomable enclosure diagram.
@@ -25,44 +21,21 @@ type HotspotsVariant = "bubble" | "treemap" | "enclosure";
  * <pq-hotspots-chart src="/api/analysis/hotspots" variant="enclosure"></pq-hotspots-chart>
  * ```
  */
-@customElement("pq-hotspots-chart")
-export class PqHotspotsChart extends LitElement {
-  private fetcher = new DataFetchController<ComplexityHotspot>(this);
-
-  @property({ type: Array }) data?: ComplexityHotspot[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property() variant: HotspotsVariant = "bubble";
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): ComplexityHotspot[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    if (this.variant === "treemap") {
-      return html`<pq-treemap
-        .data=${mapHotspotsToTreemap(this.resolvedData)}
-        .theme=${this.theme}
-        show-labels
-      ></pq-treemap>`;
-    }
-    if (this.variant === "enclosure") {
-      return html`<pq-enclosure .data=${mapHotspotsToEnclosure(this.resolvedData)} .theme=${this.theme}></pq-enclosure>`;
-    }
-    return html`<pq-bubble
-      .data=${mapHotspotsToBubble(this.resolvedData)}
-      .theme=${this.theme}
-    ></pq-bubble>`;
-  }
-}
+export const PqHotspotsChart = defineDomainChart<ComplexityHotspot>({
+  tag: "pq-hotspots-chart",
+  defaultVariant: "bubble",
+  variants: {
+    bubble: (data, theme) =>
+      html`<pq-bubble .data=${mapHotspotsToBubble(data)} .theme=${theme}></pq-bubble>`,
+    enclosure: (data, theme) =>
+      html`<pq-enclosure .data=${mapHotspotsToEnclosure(data)} .theme=${theme}></pq-enclosure>`,
+    treemap: (data, theme) =>
+      html`<pq-treemap .data=${mapHotspotsToTreemap(data)} .theme=${theme} show-labels></pq-treemap>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-hotspots-chart": PqHotspotsChart;
+    "pq-hotspots-chart": InstanceType<typeof PqHotspotsChart>;
   }
 }

--- a/packages/charts/src/domain/index.ts
+++ b/packages/charts/src/domain/index.ts
@@ -4,6 +4,8 @@ export { PqAuthorChurnChart } from "./author-churn-chart.visual";
 export { PqAuthorsChart } from "./authors-chart.visual";
 export { PqCommunicationChart } from "./communication-chart.visual";
 export { PqCouplingChart } from "./coupling-chart.visual";
+export type { DomainChartConfig, VariantRenderer } from "./define-domain-chart";
+export { defineDomainChart } from "./define-domain-chart";
 export { PqEffortChart } from "./effort-chart.visual";
 export { PqEntityChurnChart } from "./entity-churn-chart.visual";
 export { PqFragmentationChart } from "./fragmentation-chart.visual";

--- a/packages/charts/src/domain/main-dev-chart.visual.ts
+++ b/packages/charts/src/domain/main-dev-chart.visual.ts
@@ -1,13 +1,9 @@
 import type { MainDev } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapMainDevToBar, mapMainDevToTreemap } from "../mappers/main-dev.mapper";
-import type { ThemePreset } from "../types";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/ranked-bar.visual";
 import "../generic/treemap.visual";
-
-type MainDevVariant = "bar" | "treemap";
 
 /**
  * Main developer chart showing code ownership percentage as bar or treemap.
@@ -24,45 +20,25 @@ type MainDevVariant = "bar" | "treemap";
  * <pq-main-dev-chart src="/api/analysis/main-dev" variant="bar" limit="15"></pq-main-dev-chart>
  * ```
  */
-@customElement("pq-main-dev-chart")
-export class PqMainDevChart extends LitElement {
-  private fetcher = new DataFetchController<MainDev>(this);
-
-  @property({ type: Array }) data?: MainDev[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property() variant: MainDevVariant = "bar";
-  @property({ type: Number }) limit = 20;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): MainDev[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    if (this.variant === "treemap") {
-      return html`<pq-treemap
-        .data=${mapMainDevToTreemap(this.resolvedData)}
-        .theme=${this.theme}
-        show-labels
-      ></pq-treemap>`;
-    }
-    return html`<pq-ranked-bar
-      .data=${mapMainDevToBar(this.resolvedData)}
-      .limit=${this.limit}
-      .theme=${this.theme}
-      sort="desc"
-      horizontal
-    ></pq-ranked-bar>`;
-  }
-}
+export const PqMainDevChart = defineDomainChart<MainDev>({
+  tag: "pq-main-dev-chart",
+  defaultVariant: "bar",
+  variants: {
+    bar: (data, theme, limit) =>
+      html`<pq-ranked-bar
+        .data=${mapMainDevToBar(data)}
+        .limit=${limit}
+        .theme=${theme}
+        sort="desc"
+        horizontal
+      ></pq-ranked-bar>`,
+    treemap: (data, theme) =>
+      html`<pq-treemap .data=${mapMainDevToTreemap(data)} .theme=${theme} show-labels></pq-treemap>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-main-dev-chart": PqMainDevChart;
+    "pq-main-dev-chart": InstanceType<typeof PqMainDevChart>;
   }
 }

--- a/packages/charts/src/domain/main-dev-revs-chart.visual.ts
+++ b/packages/charts/src/domain/main-dev-revs-chart.visual.ts
@@ -1,13 +1,9 @@
 import type { MainDevByRevs } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapMainDevToBar, mapMainDevToTreemap } from "../mappers/main-dev.mapper";
-import type { ThemePreset } from "../types";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/ranked-bar.visual";
 import "../generic/treemap.visual";
-
-type MainDevRevsVariant = "bar" | "treemap";
 
 /**
  * Main developer by revisions chart showing ownership by revision count as bar or treemap.
@@ -24,45 +20,25 @@ type MainDevRevsVariant = "bar" | "treemap";
  * <pq-main-dev-revs-chart src="/api/analysis/main-dev-revs" variant="treemap"></pq-main-dev-revs-chart>
  * ```
  */
-@customElement("pq-main-dev-revs-chart")
-export class PqMainDevRevsChart extends LitElement {
-  private fetcher = new DataFetchController<MainDevByRevs>(this);
-
-  @property({ type: Array }) data?: MainDevByRevs[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property() variant: MainDevRevsVariant = "bar";
-  @property({ type: Number }) limit = 20;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): MainDevByRevs[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    if (this.variant === "treemap") {
-      return html`<pq-treemap
-        .data=${mapMainDevToTreemap(this.resolvedData)}
-        .theme=${this.theme}
-        show-labels
-      ></pq-treemap>`;
-    }
-    return html`<pq-ranked-bar
-      .data=${mapMainDevToBar(this.resolvedData)}
-      .limit=${this.limit}
-      .theme=${this.theme}
-      sort="desc"
-      horizontal
-    ></pq-ranked-bar>`;
-  }
-}
+export const PqMainDevRevsChart = defineDomainChart<MainDevByRevs>({
+  tag: "pq-main-dev-revs-chart",
+  defaultVariant: "bar",
+  variants: {
+    bar: (data, theme, limit) =>
+      html`<pq-ranked-bar
+        .data=${mapMainDevToBar(data)}
+        .limit=${limit}
+        .theme=${theme}
+        sort="desc"
+        horizontal
+      ></pq-ranked-bar>`,
+    treemap: (data, theme) =>
+      html`<pq-treemap .data=${mapMainDevToTreemap(data)} .theme=${theme} show-labels></pq-treemap>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-main-dev-revs-chart": PqMainDevRevsChart;
+    "pq-main-dev-revs-chart": InstanceType<typeof PqMainDevRevsChart>;
   }
 }

--- a/packages/charts/src/domain/messages-chart.visual.ts
+++ b/packages/charts/src/domain/messages-chart.visual.ts
@@ -1,9 +1,7 @@
 import type { MessageEntry } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapMessagesToBar } from "../mappers/messages.mapper";
-import type { ThemePreset } from "../types";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/ranked-bar.visual";
 
 /**
@@ -20,37 +18,23 @@ import "../generic/ranked-bar.visual";
  * <pq-messages-chart src="/api/analysis/messages" limit="10"></pq-messages-chart>
  * ```
  */
-@customElement("pq-messages-chart")
-export class PqMessagesChart extends LitElement {
-  private fetcher = new DataFetchController<MessageEntry>(this);
-
-  @property({ type: Array }) data?: MessageEntry[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property({ type: Number }) limit = 20;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): MessageEntry[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    return html`<pq-ranked-bar
-      .data=${mapMessagesToBar(this.resolvedData)}
-      .limit=${this.limit}
-      .theme=${this.theme}
-      sort="desc"
-      horizontal
-    ></pq-ranked-bar>`;
-  }
-}
+export const PqMessagesChart = defineDomainChart<MessageEntry>({
+  tag: "pq-messages-chart",
+  defaultVariant: "bar",
+  variants: {
+    bar: (data, theme, limit) =>
+      html`<pq-ranked-bar
+        .data=${mapMessagesToBar(data)}
+        .limit=${limit}
+        .theme=${theme}
+        sort="desc"
+        horizontal
+      ></pq-ranked-bar>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-messages-chart": PqMessagesChart;
+    "pq-messages-chart": InstanceType<typeof PqMessagesChart>;
   }
 }

--- a/packages/charts/src/domain/ownership-chart.visual.ts
+++ b/packages/charts/src/domain/ownership-chart.visual.ts
@@ -1,13 +1,9 @@
 import type { EntityOwnership } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapOwnershipToDoughnut, mapOwnershipToStacked } from "../mappers/ownership.mapper";
-import type { ThemePreset } from "../types";
-import "../generic/stacked-bar.visual";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/doughnut.visual";
-
-type OwnershipVariant = "stacked" | "doughnut";
+import "../generic/stacked-bar.visual";
 
 /**
  * Entity ownership chart showing author contributions as stacked bar or doughnut.
@@ -24,41 +20,24 @@ type OwnershipVariant = "stacked" | "doughnut";
  * <pq-ownership-chart src="/api/analysis/ownership" variant="stacked"></pq-ownership-chart>
  * ```
  */
-@customElement("pq-ownership-chart")
-export class PqOwnershipChart extends LitElement {
-  private fetcher = new DataFetchController<EntityOwnership>(this);
-
-  @property({ type: Array }) data?: EntityOwnership[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property() variant: OwnershipVariant = "stacked";
-  @property() entity = "";
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): EntityOwnership[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    if (this.variant === "doughnut") {
-      return html`<pq-doughnut
-        .data=${mapOwnershipToDoughnut(this.resolvedData, this.entity)}
-        .theme=${this.theme}
-      ></pq-doughnut>`;
-    }
-    return html`<pq-stacked-bar
-      .data=${mapOwnershipToStacked(this.resolvedData)}
-      .theme=${this.theme}
-    ></pq-stacked-bar>`;
-  }
-}
+export const PqOwnershipChart = defineDomainChart<EntityOwnership, { entity: string }>({
+  tag: "pq-ownership-chart",
+  defaultVariant: "stacked",
+  properties: { entity: {} },
+  defaults: { entity: "" },
+  variants: {
+    doughnut: (data, theme, _limit, extra) =>
+      html`<pq-doughnut
+        .data=${mapOwnershipToDoughnut(data, extra?.entity ?? "")}
+        .theme=${theme}
+      ></pq-doughnut>`,
+    stacked: (data, theme) =>
+      html`<pq-stacked-bar .data=${mapOwnershipToStacked(data)} .theme=${theme}></pq-stacked-bar>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-ownership-chart": PqOwnershipChart;
+    "pq-ownership-chart": InstanceType<typeof PqOwnershipChart>;
   }
 }

--- a/packages/charts/src/domain/refactoring-dev-chart.visual.ts
+++ b/packages/charts/src/domain/refactoring-dev-chart.visual.ts
@@ -1,13 +1,9 @@
 import type { RefactoringMainDev } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapRefactoringDevToBar, mapRefactoringDevToTreemap } from "../mappers/main-dev.mapper";
-import type { ThemePreset } from "../types";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/ranked-bar.visual";
 import "../generic/treemap.visual";
-
-type RefactoringDevVariant = "bar" | "treemap";
 
 /**
  * Refactoring developer chart showing refactoring ownership as bar or treemap.
@@ -24,45 +20,29 @@ type RefactoringDevVariant = "bar" | "treemap";
  * <pq-refactoring-dev-chart src="/api/analysis/refactoring-dev" variant="bar"></pq-refactoring-dev-chart>
  * ```
  */
-@customElement("pq-refactoring-dev-chart")
-export class PqRefactoringDevChart extends LitElement {
-  private fetcher = new DataFetchController<RefactoringMainDev>(this);
-
-  @property({ type: Array }) data?: RefactoringMainDev[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property() variant: RefactoringDevVariant = "bar";
-  @property({ type: Number }) limit = 20;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): RefactoringMainDev[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    if (this.variant === "treemap") {
-      return html`<pq-treemap
-        .data=${mapRefactoringDevToTreemap(this.resolvedData)}
-        .theme=${this.theme}
+export const PqRefactoringDevChart = defineDomainChart<RefactoringMainDev>({
+  tag: "pq-refactoring-dev-chart",
+  defaultVariant: "bar",
+  variants: {
+    bar: (data, theme, limit) =>
+      html`<pq-ranked-bar
+        .data=${mapRefactoringDevToBar(data)}
+        .limit=${limit}
+        .theme=${theme}
+        sort="desc"
+        horizontal
+      ></pq-ranked-bar>`,
+    treemap: (data, theme) =>
+      html`<pq-treemap
+        .data=${mapRefactoringDevToTreemap(data)}
+        .theme=${theme}
         show-labels
-      ></pq-treemap>`;
-    }
-    return html`<pq-ranked-bar
-      .data=${mapRefactoringDevToBar(this.resolvedData)}
-      .limit=${this.limit}
-      .theme=${this.theme}
-      sort="desc"
-      horizontal
-    ></pq-ranked-bar>`;
-  }
-}
+      ></pq-treemap>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-refactoring-dev-chart": PqRefactoringDevChart;
+    "pq-refactoring-dev-chart": InstanceType<typeof PqRefactoringDevChart>;
   }
 }

--- a/packages/charts/src/domain/revisions-chart.visual.ts
+++ b/packages/charts/src/domain/revisions-chart.visual.ts
@@ -1,13 +1,9 @@
 import type { Revision } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapRevisionsToBar, mapRevisionsToTreemap } from "../mappers/revisions.mapper";
-import type { ThemePreset } from "../types";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/ranked-bar.visual";
 import "../generic/treemap.visual";
-
-type RevisionsVariant = "bar" | "treemap";
 
 /**
  * Revisions chart showing file revision count as ranked bar or treemap.
@@ -24,45 +20,25 @@ type RevisionsVariant = "bar" | "treemap";
  * <pq-revisions-chart src="/api/analysis/revisions" variant="treemap"></pq-revisions-chart>
  * ```
  */
-@customElement("pq-revisions-chart")
-export class PqRevisionsChart extends LitElement {
-  private fetcher = new DataFetchController<Revision>(this);
-
-  @property({ type: Array }) data?: Revision[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property() variant: RevisionsVariant = "bar";
-  @property({ type: Number }) limit = 20;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): Revision[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    if (this.variant === "treemap") {
-      return html`<pq-treemap
-        .data=${mapRevisionsToTreemap(this.resolvedData)}
-        .theme=${this.theme}
-        show-labels
-      ></pq-treemap>`;
-    }
-    return html`<pq-ranked-bar
-      .data=${mapRevisionsToBar(this.resolvedData)}
-      .limit=${this.limit}
-      .theme=${this.theme}
-      sort="desc"
-      horizontal
-    ></pq-ranked-bar>`;
-  }
-}
+export const PqRevisionsChart = defineDomainChart<Revision>({
+  tag: "pq-revisions-chart",
+  defaultVariant: "bar",
+  variants: {
+    bar: (data, theme, limit) =>
+      html`<pq-ranked-bar
+        .data=${mapRevisionsToBar(data)}
+        .limit=${limit}
+        .theme=${theme}
+        sort="desc"
+        horizontal
+      ></pq-ranked-bar>`,
+    treemap: (data, theme) =>
+      html`<pq-treemap .data=${mapRevisionsToTreemap(data)} .theme=${theme} show-labels></pq-treemap>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-revisions-chart": PqRevisionsChart;
+    "pq-revisions-chart": InstanceType<typeof PqRevisionsChart>;
   }
 }

--- a/packages/charts/src/domain/soc-chart.visual.ts
+++ b/packages/charts/src/domain/soc-chart.visual.ts
@@ -1,9 +1,7 @@
 import type { Soc } from "@prj-conq/behave";
-import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { DataFetchController } from "../controllers/data-fetch.controller";
+import { html } from "lit";
 import { mapSocToBar } from "../mappers/soc.mapper";
-import type { ThemePreset } from "../types";
+import { defineDomainChart } from "./define-domain-chart";
 import "../generic/ranked-bar.visual";
 
 /**
@@ -20,37 +18,23 @@ import "../generic/ranked-bar.visual";
  * <pq-soc-chart src="/api/analysis/soc" limit="15"></pq-soc-chart>
  * ```
  */
-@customElement("pq-soc-chart")
-export class PqSocChart extends LitElement {
-  private fetcher = new DataFetchController<Soc>(this);
-
-  @property({ type: Array }) data?: Soc[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property({ type: Number }) limit = 20;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-  }
-
-  private get resolvedData(): Soc[] {
-    return this.data ?? this.fetcher.data ?? [];
-  }
-
-  protected override render() {
-    return html`<pq-ranked-bar
-      .data=${mapSocToBar(this.resolvedData)}
-      .limit=${this.limit}
-      .theme=${this.theme}
-      sort="desc"
-      horizontal
-    ></pq-ranked-bar>`;
-  }
-}
+export const PqSocChart = defineDomainChart<Soc>({
+  tag: "pq-soc-chart",
+  defaultVariant: "bar",
+  variants: {
+    bar: (data, theme, limit) =>
+      html`<pq-ranked-bar
+        .data=${mapSocToBar(data)}
+        .limit=${limit}
+        .theme=${theme}
+        sort="desc"
+        horizontal
+      ></pq-ranked-bar>`,
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-soc-chart": PqSocChart;
+    "pq-soc-chart": InstanceType<typeof PqSocChart>;
   }
 }

--- a/packages/charts/src/generic/bubble.visual.ts
+++ b/packages/charts/src/generic/bubble.visual.ts
@@ -1,11 +1,6 @@
-import type { TooltipItem } from "chart.js";
-import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { ref } from "lit/directives/ref.js";
-import { ChartController } from "../controllers/chart.controller";
-import { DataFetchController } from "../controllers/data-fetch.controller";
-import { ThemeController } from "../controllers/theme.controller";
-import type { BubbleItem, ThemePreset } from "../types";
+import type { ChartConfiguration, ChartTypeRegistry, TooltipItem } from "chart.js";
+import type { BubbleItem } from "../types";
+import { defineGenericChart } from "./define-generic-chart";
 
 /**
  * Bubble chart web component backed by Chart.js.
@@ -32,53 +27,25 @@ import type { BubbleItem, ThemePreset } from "../types";
  * ></pq-bubble>
  * ```
  */
-@customElement("pq-bubble")
-export class PqBubble extends LitElement {
-  static override styles = css`
-    :host { display: block; position: relative; width: 100%; height: 100%; }
-    canvas { width: 100% !important; height: 100% !important; }
-    .state-message {
-      display: flex; align-items: center; justify-content: center;
-      min-height: 200px;
-      color: var(--pq-chart-text, #e0e0e0);
-      font-family: var(--pq-chart-font-family, system-ui, sans-serif);
-    }
-  `;
+export const PqBubble = defineGenericChart<BubbleItem, { xLabel: string; yLabel: string }>({
+  tag: "pq-bubble",
+  properties: {
+    xLabel: { attribute: "x-label" },
+    yLabel: { attribute: "y-label" },
+  },
+  defaults: { xLabel: "", yLabel: "" },
+  buildConfig: ({ resolved, themeCtrl, props }): ChartConfiguration => {
+    const themePlugins = themeCtrl.options.plugins;
+    const themeScales = themeCtrl.options.scales;
 
-  private fetcher = new DataFetchController<BubbleItem>(this);
-  private chartCtrl = new ChartController(this);
-  private themeCtrl = new ThemeController(this);
-
-  @property({ type: Array }) data?: BubbleItem[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property({ attribute: "x-label" }) xLabel = "";
-  @property({ attribute: "y-label" }) yLabel = "";
-  @property({ type: Boolean, attribute: "animated" }) animated = true;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("theme")) this.themeCtrl.update(this.theme);
-    if (changed.has("animated")) this.chartCtrl.animate = this.animated;
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-    this.renderChart();
-  }
-
-  private renderChart(): void {
-    const resolved = this.data ?? this.fetcher.data;
-    if (!resolved?.length) return;
-
-    const themePlugins = this.themeCtrl.options.plugins;
-    const themeScales = this.themeCtrl.options.scales;
-
-    this.chartCtrl.update({
+    return {
       type: "bubble",
       data: {
         datasets: [
           {
             data: resolved.map((item) => ({ x: item.x, y: item.y, r: item.r })),
-            backgroundColor: this.themeCtrl.colors[0],
-            borderColor: this.themeCtrl.colors[0],
+            backgroundColor: themeCtrl.colors[0],
+            borderColor: themeCtrl.colors[0],
           },
         ],
       },
@@ -91,11 +58,12 @@ export class PqBubble extends LitElement {
           tooltip: {
             ...themePlugins.tooltip,
             callbacks: {
-              label: (ctx: TooltipItem<"bubble">) => {
+              label: (ctx: TooltipItem<keyof ChartTypeRegistry>) => {
                 const item = resolved[ctx.dataIndex];
                 const label = item ? item.label : "";
-                const raw = ctx.raw as { r?: number };
-                return `${label}: (${ctx.parsed.x}, ${ctx.parsed.y}, r=${raw.r})`;
+                const raw = ctx.raw as { r?: number; x?: number; y?: number };
+                const parsed = ctx.parsed as { x?: number; y?: number };
+                return `${label}: (${parsed.x}, ${parsed.y}, r=${raw.r})`;
               },
             },
           },
@@ -104,31 +72,20 @@ export class PqBubble extends LitElement {
           ...themeScales,
           x: {
             ...themeScales.x,
-            title: { display: !!this.xLabel, text: this.xLabel },
+            title: { display: !!props.xLabel, text: props.xLabel },
           },
           y: {
             ...themeScales.y,
-            title: { display: !!this.yLabel, text: this.yLabel },
+            title: { display: !!props.yLabel, text: props.yLabel },
           },
         },
       },
-    });
-  }
-
-  protected override render() {
-    if (this.fetcher.state === "loading")
-      return html`<div class="state-message"><slot name="loading">Loading…</slot></div>`;
-    if (this.fetcher.state === "error")
-      return html`<div class="state-message"><slot name="error">Failed to load data.</slot></div>`;
-    const resolved = this.data ?? this.fetcher.data;
-    if (resolved && resolved.length === 0)
-      return html`<div class="state-message"><slot name="empty">No data.</slot></div>`;
-    return html`<canvas ${ref(this.chartCtrl.canvasRef)}></canvas>`;
-  }
-}
+    };
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-bubble": PqBubble;
+    "pq-bubble": InstanceType<typeof PqBubble>;
   }
 }

--- a/packages/charts/src/generic/define-generic-chart.ts
+++ b/packages/charts/src/generic/define-generic-chart.ts
@@ -1,0 +1,242 @@
+import type { ChartConfiguration } from "chart.js";
+import { css, html, LitElement } from "lit";
+import { ref } from "lit/directives/ref.js";
+import { ChartController } from "../controllers/chart.controller";
+import { DataFetchController } from "../controllers/data-fetch.controller";
+import { ThemeController } from "../controllers/theme.controller";
+import type { ThemePreset } from "../types";
+
+/**
+ * Contextual object passed to the `buildConfig` strategy function.
+ * Contains resolved data, all three controllers, and a snapshot of
+ * the component instance for reading custom properties.
+ *
+ * @typeParam T - The domain data item type this chart renders.
+ * @typeParam Props - Record of component-specific property names to their types.
+ */
+export type BuildConfigContext<T, Props extends Record<string, unknown>> = {
+  /** Resolved non-empty data array (inline `data` prop or fetched via `src`). */
+  resolved: T[];
+  /** Provides `colors`, `theme`, and `options` (scales + plugins) for Chart.js config. */
+  themeCtrl: ThemeController;
+  /** Provides `animate` flag; rarely needed in buildConfig but available. */
+  chartCtrl: ChartController;
+  /** Current values of all component-specific properties. */
+  props: Props;
+};
+
+/**
+ * Strategy function that builds a Chart.js configuration from resolved data.
+ *
+ * @typeParam T - The domain data item type this chart renders.
+ * @typeParam Props - Record of component-specific property names to their types.
+ * @param ctx - Context with resolved data, controllers, and component props.
+ * @returns A complete Chart.js `ChartConfiguration` object.
+ */
+export type BuildConfigFn<T, Props extends Record<string, unknown>> = (
+  ctx: BuildConfigContext<T, Props>,
+) => ChartConfiguration;
+
+/**
+ * Lit `PropertyDeclaration`-compatible descriptor for a single reactive property.
+ * Matches the shape accepted by Lit's `static properties` map.
+ *
+ * @example
+ * ```ts
+ * const decl: LitPropertyDeclaration = { type: Number };
+ * const decl2: LitPropertyDeclaration = { attribute: "x-label" };
+ * ```
+ */
+export type LitPropertyDeclaration = {
+  type?: typeof Boolean | typeof Number | typeof String | typeof Array | typeof Object;
+  attribute?: string | boolean;
+  reflect?: boolean;
+  converter?:
+    | ((value: string | null, type?: unknown) => unknown)
+    | {
+        fromAttribute?: (v: string | null, t?: unknown) => unknown;
+        toAttribute?: (v: unknown, t?: unknown) => unknown;
+      };
+  hasChanged?: (value: unknown, oldValue: unknown) => boolean;
+  state?: boolean;
+  noAccessor?: boolean;
+  useDefault?: boolean;
+};
+
+/**
+ * Configuration object passed to {@link defineGenericChart}.
+ *
+ * @typeParam T - The domain data item type this chart renders.
+ * @typeParam Props - Record of component-specific property names to their types.
+ *
+ * @example
+ * ```ts
+ * const config: GenericChartConfig<BubbleItem, { xLabel: string; yLabel: string }> = {
+ *   tag: "pq-bubble",
+ *   properties: {
+ *     xLabel: { attribute: "x-label" },
+ *     yLabel: { attribute: "y-label" },
+ *   },
+ *   defaults: { xLabel: "", yLabel: "" },
+ *   buildConfig: ({ resolved, themeCtrl, props }) => ({ type: "bubble", data: {}, options: {} }),
+ * };
+ * ```
+ */
+export type GenericChartConfig<T, Props extends Record<string, unknown> = Record<string, never>> = {
+  /**
+   * Custom element tag name (e.g. `"pq-bubble"`).
+   * Must match the existing registered tag name — not changing it.
+   */
+  tag: string;
+
+  /**
+   * Component-specific reactive properties, declared using Lit's `static properties` map format.
+   * Do NOT include `data`, `src`, `theme`, or `animated` — these are injected by the factory.
+   *
+   * @example
+   * ```ts
+   * properties: {
+   *   limit: { type: Number },
+   *   horizontal: { type: Boolean },
+   *   sort: {},  // string, no type coercion
+   * }
+   * ```
+   */
+  properties: Record<string, LitPropertyDeclaration> & {
+    [K in keyof Props]?: LitPropertyDeclaration;
+  };
+
+  /**
+   * Default values for each component-specific property.
+   * Every key in `properties` MUST have a corresponding default here.
+   *
+   * @example
+   * ```ts
+   * defaults: { limit: 0, horizontal: true, sort: "desc" }
+   * ```
+   */
+  defaults: Props;
+
+  /**
+   * Strategy function that builds the Chart.js configuration.
+   * Called only when resolved data is non-empty.
+   *
+   * @param ctx - Contains resolved data, controllers, and component props.
+   * @returns Chart.js `ChartConfiguration` object.
+   */
+  buildConfig: BuildConfigFn<T, Props>;
+};
+
+/**
+ * Factory that creates and registers a Chart.js-backed Lit Web Component.
+ *
+ * All shared infrastructure (styles, controllers, base properties, lifecycle,
+ * render states) is handled by the factory. Consumers supply only their
+ * component-specific properties and a `buildConfig` strategy function.
+ *
+ * No class inheritance. No abstract methods. Composition only.
+ *
+ * @typeParam T - The domain data item type this chart renders.
+ * @typeParam Props - Record of component-specific property names to their types.
+ * @param config - Component configuration: tag, properties, defaults, buildConfig strategy.
+ * @returns The generated Lit element class (use for `HTMLElementTagNameMap` augmentation).
+ *
+ * @example
+ * ```ts
+ * export const PqBubble = defineGenericChart<BubbleItem, { xLabel: string; yLabel: string }>({
+ *   tag: "pq-bubble",
+ *   properties: {
+ *     xLabel: { attribute: "x-label" },
+ *     yLabel: { attribute: "y-label" },
+ *   },
+ *   defaults: { xLabel: "", yLabel: "" },
+ *   buildConfig: ({ resolved, themeCtrl, props }) => ({ type: "bubble", data: {}, options: {} }),
+ * });
+ * ```
+ */
+export function defineGenericChart<
+  T,
+  Props extends Record<string, unknown> = Record<string, never>,
+>(config: GenericChartConfig<T, Props>): typeof LitElement {
+  const sharedStyles = css`
+    :host { display: block; position: relative; width: 100%; height: 100%; }
+    canvas { width: 100% !important; height: 100% !important; }
+    .state-message {
+      display: flex; align-items: center; justify-content: center;
+      min-height: 200px;
+      color: var(--pq-chart-text, #e0e0e0);
+      font-family: var(--pq-chart-font-family, system-ui, sans-serif);
+    }
+  `;
+
+  class GenericChart extends LitElement {
+    static override styles = sharedStyles;
+
+    static override properties = {
+      data: { type: Array },
+      src: {},
+      theme: {},
+      animated: { type: Boolean, attribute: "animated" },
+      ...config.properties,
+    };
+
+    private fetcher = new DataFetchController<T>(this);
+    private chartCtrl = new ChartController(this);
+    private themeCtrl = new ThemeController(this);
+
+    data?: T[];
+    src?: string;
+    theme?: ThemePreset;
+    animated = true;
+
+    constructor() {
+      super();
+      for (const [key, value] of Object.entries(config.defaults)) {
+        (this as unknown as Record<string, unknown>)[key] = value;
+      }
+    }
+
+    protected override async updated(changed: Map<string, unknown>): Promise<void> {
+      if (changed.has("theme")) this.themeCtrl.update(this.theme);
+      if (changed.has("animated")) this.chartCtrl.animate = this.animated;
+      if (changed.has("src") || changed.has("data"))
+        await this.fetcher.fetch(this.src ?? "", !!this.data);
+      this.renderChart();
+    }
+
+    private renderChart(): void {
+      const resolved = this.data ?? this.fetcher.data;
+      if (!resolved?.length) return;
+
+      const props = Object.fromEntries(
+        Object.keys(config.properties).map((key) => [
+          key,
+          (this as unknown as Record<string, unknown>)[key],
+        ]),
+      ) as Props;
+
+      const chartConfig = config.buildConfig({
+        resolved,
+        themeCtrl: this.themeCtrl,
+        chartCtrl: this.chartCtrl,
+        props,
+      });
+
+      this.chartCtrl.update(chartConfig);
+    }
+
+    protected override render() {
+      if (this.fetcher.state === "loading")
+        return html`<div class="state-message"><slot name="loading">Loading…</slot></div>`;
+      if (this.fetcher.state === "error")
+        return html`<div class="state-message"><slot name="error">Failed to load data.</slot></div>`;
+      const resolved = this.data ?? this.fetcher.data;
+      if (resolved && resolved.length === 0)
+        return html`<div class="state-message"><slot name="empty">No data.</slot></div>`;
+      return html`<canvas ${ref(this.chartCtrl.canvasRef)}></canvas>`;
+    }
+  }
+
+  customElements.define(config.tag, GenericChart);
+  return GenericChart;
+}

--- a/packages/charts/src/generic/define-generic-chart.ts
+++ b/packages/charts/src/generic/define-generic-chart.ts
@@ -237,6 +237,8 @@ export function defineGenericChart<
     }
   }
 
-  customElements.define(config.tag, GenericChart);
+  if (!customElements.get(config.tag)) {
+    customElements.define(config.tag, GenericChart);
+  }
   return GenericChart;
 }

--- a/packages/charts/src/generic/define-generic-chart.ts
+++ b/packages/charts/src/generic/define-generic-chart.ts
@@ -170,9 +170,9 @@ export function defineGenericChart<
   `;
 
   class GenericChart extends LitElement {
-    static override styles = sharedStyles;
+    static override readonly styles = sharedStyles;
 
-    static override properties = {
+    static override readonly properties = {
       data: { type: Array },
       src: {},
       theme: {},
@@ -180,9 +180,9 @@ export function defineGenericChart<
       ...config.properties,
     };
 
-    private fetcher = new DataFetchController<T>(this);
-    private chartCtrl = new ChartController(this);
-    private themeCtrl = new ThemeController(this);
+    private readonly fetcher = new DataFetchController<T>(this);
+    private readonly chartCtrl = new ChartController(this);
+    private readonly themeCtrl = new ThemeController(this);
 
     data?: T[];
     src?: string;
@@ -231,7 +231,7 @@ export function defineGenericChart<
       if (this.fetcher.state === "error")
         return html`<div class="state-message"><slot name="error">Failed to load data.</slot></div>`;
       const resolved = this.data ?? this.fetcher.data;
-      if (resolved && resolved.length === 0)
+      if (resolved?.length === 0)
         return html`<div class="state-message"><slot name="empty">No data.</slot></div>`;
       return html`<canvas ${ref(this.chartCtrl.canvasRef)}></canvas>`;
     }

--- a/packages/charts/src/generic/doughnut.visual.ts
+++ b/packages/charts/src/generic/doughnut.visual.ts
@@ -1,11 +1,6 @@
-import type { Chart } from "chart.js";
-import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { ref } from "lit/directives/ref.js";
-import { ChartController } from "../controllers/chart.controller";
-import { DataFetchController } from "../controllers/data-fetch.controller";
-import { ThemeController } from "../controllers/theme.controller";
-import type { DoughnutItem, ThemePreset } from "../types";
+import type { Chart, ChartConfiguration } from "chart.js";
+import type { DoughnutItem } from "../types";
+import { defineGenericChart } from "./define-generic-chart";
 
 /**
  * Doughnut chart web component backed by Chart.js.
@@ -31,46 +26,21 @@ import type { DoughnutItem, ThemePreset } from "../types";
  * ></pq-doughnut>
  * ```
  */
-@customElement("pq-doughnut")
-export class PqDoughnut extends LitElement {
-  static override styles = css`
-    :host { display: block; position: relative; width: 100%; height: 100%; }
-    canvas { width: 100% !important; height: 100% !important; }
-    .state-message {
-      display: flex; align-items: center; justify-content: center;
-      min-height: 200px;
-      color: var(--pq-chart-text, #e0e0e0);
-      font-family: var(--pq-chart-font-family, system-ui, sans-serif);
-    }
-  `;
-
-  private fetcher = new DataFetchController<DoughnutItem>(this);
-  private chartCtrl = new ChartController(this);
-  private themeCtrl = new ThemeController(this);
-
-  @property({ type: Array }) data?: DoughnutItem[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property({ type: Boolean, attribute: "show-legend" }) showLegend = true;
-  @property({ attribute: "center-label" }) centerLabel = "";
-  @property({ type: Boolean, attribute: "animated" }) animated = true;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("theme")) this.themeCtrl.update(this.theme);
-    if (changed.has("animated")) this.chartCtrl.animate = this.animated;
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-    this.renderChart();
-  }
-
-  private renderChart(): void {
-    const resolved = this.data ?? this.fetcher.data;
-    if (!resolved?.length) return;
-
-    const themePlugins = this.themeCtrl.options.plugins;
-    const centerLabel = this.centerLabel;
-    const themeText = this.themeCtrl.theme.text;
-    const themeFontFamily = this.themeCtrl.theme.fontFamily;
+export const PqDoughnut = defineGenericChart<
+  DoughnutItem,
+  { showLegend: boolean; centerLabel: string }
+>({
+  tag: "pq-doughnut",
+  properties: {
+    showLegend: { type: Boolean, attribute: "show-legend" },
+    centerLabel: { attribute: "center-label" },
+  },
+  defaults: { showLegend: true, centerLabel: "" },
+  buildConfig: ({ resolved, themeCtrl, props }): ChartConfiguration => {
+    const themePlugins = themeCtrl.options.plugins;
+    const centerLabel = props.centerLabel;
+    const themeText = themeCtrl.theme.text;
+    const themeFontFamily = themeCtrl.theme.fontFamily;
 
     const centerLabelPlugin = centerLabel
       ? {
@@ -91,15 +61,15 @@ export class PqDoughnut extends LitElement {
         }
       : null;
 
-    this.chartCtrl.update({
+    return {
       type: "doughnut",
       data: {
         labels: resolved.map((d) => d.label),
         datasets: [
           {
             data: resolved.map((d) => d.value),
-            backgroundColor: this.themeCtrl.colors.slice(0, resolved.length),
-            borderColor: this.themeCtrl.colors.slice(0, resolved.length),
+            backgroundColor: themeCtrl.colors.slice(0, resolved.length),
+            borderColor: themeCtrl.colors.slice(0, resolved.length),
             borderWidth: 1,
           },
         ],
@@ -109,27 +79,16 @@ export class PqDoughnut extends LitElement {
         maintainAspectRatio: false,
         plugins: {
           ...themePlugins,
-          legend: { ...themePlugins.legend, display: this.showLegend },
+          legend: { ...themePlugins.legend, display: props.showLegend },
           ...(centerLabelPlugin ? { centerLabel: centerLabelPlugin } : {}),
         },
       },
-    });
-  }
-
-  protected override render() {
-    if (this.fetcher.state === "loading")
-      return html`<div class="state-message"><slot name="loading">Loading…</slot></div>`;
-    if (this.fetcher.state === "error")
-      return html`<div class="state-message"><slot name="error">Failed to load data.</slot></div>`;
-    const resolved = this.data ?? this.fetcher.data;
-    if (resolved && resolved.length === 0)
-      return html`<div class="state-message"><slot name="empty">No data.</slot></div>`;
-    return html`<canvas ${ref(this.chartCtrl.canvasRef)}></canvas>`;
-  }
-}
+    };
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-doughnut": PqDoughnut;
+    "pq-doughnut": InstanceType<typeof PqDoughnut>;
   }
 }

--- a/packages/charts/src/generic/grouped-bar.visual.ts
+++ b/packages/charts/src/generic/grouped-bar.visual.ts
@@ -1,11 +1,7 @@
-import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { ref } from "lit/directives/ref.js";
-import { ChartController } from "../controllers/chart.controller";
-import { DataFetchController } from "../controllers/data-fetch.controller";
-import { ThemeController } from "../controllers/theme.controller";
+import type { ChartConfiguration } from "chart.js";
 import { buildGroupedDatasets } from "../mappers/grouped-bar.mapper";
-import type { GroupedBarItem, ThemePreset } from "../types";
+import type { GroupedBarItem } from "../types";
+import { defineGenericChart } from "./define-generic-chart";
 
 /**
  * Grouped bar chart web component backed by Chart.js.
@@ -32,88 +28,51 @@ import type { GroupedBarItem, ThemePreset } from "../types";
  * ></pq-grouped-bar>
  * ```
  */
-@customElement("pq-grouped-bar")
-export class PqGroupedBar extends LitElement {
-  static override styles = css`
-    :host { display: block; position: relative; width: 100%; height: 100%; }
-    canvas { width: 100% !important; height: 100% !important; }
-    .state-message {
-      display: flex; align-items: center; justify-content: center;
-      min-height: 200px;
-      color: var(--pq-chart-text, #e0e0e0);
-      font-family: var(--pq-chart-font-family, system-ui, sans-serif);
-    }
-  `;
-
-  private fetcher = new DataFetchController<GroupedBarItem>(this);
-  private chartCtrl = new ChartController(this);
-  private themeCtrl = new ThemeController(this);
-
-  @property({ type: Array }) data?: GroupedBarItem[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property({ type: Number }) limit = 0;
-  @property({ type: Boolean }) horizontal = false;
-  @property({ type: Boolean, attribute: "show-legend" }) showLegend = true;
-  @property({ type: Boolean, attribute: "animated" }) animated = true;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("theme")) this.themeCtrl.update(this.theme);
-    if (changed.has("animated")) this.chartCtrl.animate = this.animated;
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-    this.renderChart();
-  }
-
-  private renderChart(): void {
-    const resolved = this.data ?? this.fetcher.data;
-    if (!resolved?.length) return;
-
-    const sliced = this.limit > 0 ? resolved.slice(0, this.limit) : resolved;
+export const PqGroupedBar = defineGenericChart<
+  GroupedBarItem,
+  { limit: number; horizontal: boolean; showLegend: boolean }
+>({
+  tag: "pq-grouped-bar",
+  properties: {
+    limit: { type: Number },
+    horizontal: { type: Boolean },
+    showLegend: { type: Boolean, attribute: "show-legend" },
+  },
+  defaults: { limit: 0, horizontal: false, showLegend: true },
+  buildConfig: ({ resolved, themeCtrl, props }): ChartConfiguration => {
+    const sliced = props.limit > 0 ? resolved.slice(0, props.limit) : resolved;
     const { labels, datasets } = buildGroupedDatasets(sliced);
+    const themePlugins = themeCtrl.options.plugins;
+    const themeScales = themeCtrl.options.scales;
 
-    const themePlugins = this.themeCtrl.options.plugins;
-    const themeScales = this.themeCtrl.options.scales;
-
-    this.chartCtrl.update({
+    return {
       type: "bar",
       data: {
         labels,
         datasets: datasets.map((ds, i) => ({
           label: ds.label,
           data: ds.data,
-          backgroundColor: this.themeCtrl.colors[i % this.themeCtrl.colors.length],
-          borderColor: this.themeCtrl.colors[i % this.themeCtrl.colors.length],
+          backgroundColor: themeCtrl.colors[i % themeCtrl.colors.length],
+          borderColor: themeCtrl.colors[i % themeCtrl.colors.length],
           borderWidth: 1,
         })),
       },
       options: {
-        indexAxis: this.horizontal ? "y" : "x",
+        indexAxis: props.horizontal ? "y" : "x",
         responsive: true,
         maintainAspectRatio: false,
         plugins: {
           ...themePlugins,
-          legend: { ...themePlugins.legend, display: this.showLegend },
+          legend: { ...themePlugins.legend, display: props.showLegend },
         },
         scales: themeScales,
       },
-    });
-  }
-
-  protected override render() {
-    if (this.fetcher.state === "loading")
-      return html`<div class="state-message"><slot name="loading">Loading…</slot></div>`;
-    if (this.fetcher.state === "error")
-      return html`<div class="state-message"><slot name="error">Failed to load data.</slot></div>`;
-    const resolved = this.data ?? this.fetcher.data;
-    if (resolved && resolved.length === 0)
-      return html`<div class="state-message"><slot name="empty">No data.</slot></div>`;
-    return html`<canvas ${ref(this.chartCtrl.canvasRef)}></canvas>`;
-  }
-}
+    };
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-grouped-bar": PqGroupedBar;
+    "pq-grouped-bar": InstanceType<typeof PqGroupedBar>;
   }
 }

--- a/packages/charts/src/generic/histogram.visual.ts
+++ b/packages/charts/src/generic/histogram.visual.ts
@@ -1,11 +1,7 @@
-import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { ref } from "lit/directives/ref.js";
-import { ChartController } from "../controllers/chart.controller";
-import { DataFetchController } from "../controllers/data-fetch.controller";
-import { ThemeController } from "../controllers/theme.controller";
+import type { ChartConfiguration } from "chart.js";
 import { binValues } from "../mappers/histogram.mapper";
-import type { HistogramItem, ThemePreset } from "../types";
+import type { HistogramItem } from "../types";
+import { defineGenericChart } from "./define-generic-chart";
 
 /**
  * Histogram chart web component backed by Chart.js.
@@ -35,58 +31,32 @@ import type { HistogramItem, ThemePreset } from "../types";
  * ></pq-histogram>
  * ```
  */
-@customElement("pq-histogram")
-export class PqHistogram extends LitElement {
-  static override styles = css`
-    :host { display: block; position: relative; width: 100%; height: 100%; }
-    canvas { width: 100% !important; height: 100% !important; }
-    .state-message {
-      display: flex; align-items: center; justify-content: center;
-      min-height: 200px;
-      color: var(--pq-chart-text, #e0e0e0);
-      font-family: var(--pq-chart-font-family, system-ui, sans-serif);
-    }
-  `;
-
-  private fetcher = new DataFetchController<HistogramItem>(this);
-  private chartCtrl = new ChartController(this);
-  private themeCtrl = new ThemeController(this);
-
-  @property({ type: Array }) data?: HistogramItem[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property({ type: Number }) bins = 10;
-  @property({ attribute: "x-label" }) xLabel = "";
-  @property({ attribute: "y-label" }) yLabel = "";
-  @property({ type: Boolean, attribute: "animated" }) animated = true;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("theme")) this.themeCtrl.update(this.theme);
-    if (changed.has("animated")) this.chartCtrl.animate = this.animated;
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-    this.renderChart();
-  }
-
-  private renderChart(): void {
-    const resolved = this.data ?? this.fetcher.data;
-    if (!resolved?.length) return;
-
+export const PqHistogram = defineGenericChart<
+  HistogramItem,
+  { bins: number; xLabel: string; yLabel: string }
+>({
+  tag: "pq-histogram",
+  properties: {
+    bins: { type: Number },
+    xLabel: { attribute: "x-label" },
+    yLabel: { attribute: "y-label" },
+  },
+  defaults: { bins: 10, xLabel: "", yLabel: "" },
+  buildConfig: ({ resolved, themeCtrl, props }): ChartConfiguration => {
     const values = resolved.map((item) => item.value);
-    const binned = binValues(values, this.bins);
+    const binned = binValues(values, props.bins);
+    const themePlugins = themeCtrl.options.plugins;
+    const themeScales = themeCtrl.options.scales;
 
-    const themePlugins = this.themeCtrl.options.plugins;
-    const themeScales = this.themeCtrl.options.scales;
-
-    this.chartCtrl.update({
+    return {
       type: "bar",
       data: {
         labels: binned.map((b) => b.label),
         datasets: [
           {
             data: binned.map((b) => b.value),
-            backgroundColor: this.themeCtrl.colors[0],
-            borderColor: this.themeCtrl.colors[0],
+            backgroundColor: themeCtrl.colors[0],
+            borderColor: themeCtrl.colors[0],
             borderWidth: 1,
             categoryPercentage: 1.0,
             barPercentage: 1.0,
@@ -104,31 +74,20 @@ export class PqHistogram extends LitElement {
           ...themeScales,
           x: {
             ...themeScales.x,
-            title: { display: !!this.xLabel, text: this.xLabel },
+            title: { display: !!props.xLabel, text: props.xLabel },
           },
           y: {
             ...themeScales.y,
-            title: { display: !!this.yLabel, text: this.yLabel },
+            title: { display: !!props.yLabel, text: props.yLabel },
           },
         },
       },
-    });
-  }
-
-  protected override render() {
-    if (this.fetcher.state === "loading")
-      return html`<div class="state-message"><slot name="loading">Loading…</slot></div>`;
-    if (this.fetcher.state === "error")
-      return html`<div class="state-message"><slot name="error">Failed to load data.</slot></div>`;
-    const resolved = this.data ?? this.fetcher.data;
-    if (resolved && resolved.length === 0)
-      return html`<div class="state-message"><slot name="empty">No data.</slot></div>`;
-    return html`<canvas ${ref(this.chartCtrl.canvasRef)}></canvas>`;
-  }
-}
+    };
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-histogram": PqHistogram;
+    "pq-histogram": InstanceType<typeof PqHistogram>;
   }
 }

--- a/packages/charts/src/generic/index.ts
+++ b/packages/charts/src/generic/index.ts
@@ -1,4 +1,11 @@
 export { PqBubble } from "./bubble.visual";
+export type {
+  BuildConfigContext,
+  BuildConfigFn,
+  GenericChartConfig,
+  LitPropertyDeclaration,
+} from "./define-generic-chart";
+export { defineGenericChart } from "./define-generic-chart";
 export { PqDoughnut } from "./doughnut.visual";
 export { PqEnclosure } from "./enclosure.visual";
 export { PqGroupedBar } from "./grouped-bar.visual";

--- a/packages/charts/src/generic/line-area.visual.ts
+++ b/packages/charts/src/generic/line-area.visual.ts
@@ -1,11 +1,7 @@
-import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { ref } from "lit/directives/ref.js";
-import { ChartController } from "../controllers/chart.controller";
-import { DataFetchController } from "../controllers/data-fetch.controller";
-import { ThemeController } from "../controllers/theme.controller";
+import type { ChartConfiguration } from "chart.js";
 import { buildLineAreaDatasets } from "../mappers/line-area.mapper";
-import type { LineAreaPoint, ThemePreset } from "../types";
+import type { LineAreaPoint } from "../types";
+import { defineGenericChart } from "./define-generic-chart";
 
 /**
  * Line/area chart web component backed by Chart.js.
@@ -35,60 +31,34 @@ import type { LineAreaPoint, ThemePreset } from "../types";
  * ></pq-line-area>
  * ```
  */
-@customElement("pq-line-area")
-export class PqLineArea extends LitElement {
-  static override styles = css`
-    :host { display: block; position: relative; width: 100%; height: 100%; }
-    canvas { width: 100% !important; height: 100% !important; }
-    .state-message {
-      display: flex; align-items: center; justify-content: center;
-      min-height: 200px;
-      color: var(--pq-chart-text, #e0e0e0);
-      font-family: var(--pq-chart-font-family, system-ui, sans-serif);
-    }
-  `;
-
-  private fetcher = new DataFetchController<LineAreaPoint>(this);
-  private chartCtrl = new ChartController(this);
-  private themeCtrl = new ThemeController(this);
-
-  @property({ type: Array }) data?: LineAreaPoint[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property({ type: Boolean }) fill = false;
-  @property({ type: Boolean }) stacked = false;
-  @property({ attribute: "x-label" }) xLabel = "";
-  @property({ attribute: "y-label" }) yLabel = "";
-  @property({ type: Boolean, attribute: "show-legend" }) showLegend = true;
-  @property({ type: Boolean, attribute: "animated" }) animated = true;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("theme")) this.themeCtrl.update(this.theme);
-    if (changed.has("animated")) this.chartCtrl.animate = this.animated;
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-    this.renderChart();
-  }
-
-  private renderChart(): void {
-    const resolved = this.data ?? this.fetcher.data;
-    if (!resolved?.length) return;
-
+export const PqLineArea = defineGenericChart<
+  LineAreaPoint,
+  { fill: boolean; stacked: boolean; xLabel: string; yLabel: string; showLegend: boolean }
+>({
+  tag: "pq-line-area",
+  properties: {
+    fill: { type: Boolean },
+    stacked: { type: Boolean },
+    xLabel: { attribute: "x-label" },
+    yLabel: { attribute: "y-label" },
+    showLegend: { type: Boolean, attribute: "show-legend" },
+  },
+  defaults: { fill: false, stacked: false, xLabel: "", yLabel: "", showLegend: true },
+  buildConfig: ({ resolved, themeCtrl, props }): ChartConfiguration => {
     const { labels, datasets } = buildLineAreaDatasets(resolved);
+    const themePlugins = themeCtrl.options.plugins;
+    const themeScales = themeCtrl.options.scales;
 
-    const themePlugins = this.themeCtrl.options.plugins;
-    const themeScales = this.themeCtrl.options.scales;
-
-    this.chartCtrl.update({
+    return {
       type: "line",
       data: {
         labels,
         datasets: datasets.map((ds, i) => ({
           label: ds.label,
           data: ds.data,
-          backgroundColor: this.themeCtrl.colors[i % this.themeCtrl.colors.length],
-          borderColor: this.themeCtrl.colors[i % this.themeCtrl.colors.length],
-          fill: this.fill ? "origin" : false,
+          backgroundColor: themeCtrl.colors[i % themeCtrl.colors.length],
+          borderColor: themeCtrl.colors[i % themeCtrl.colors.length],
+          fill: props.fill ? "origin" : false,
           tension: 0.3,
         })),
       },
@@ -97,39 +67,28 @@ export class PqLineArea extends LitElement {
         maintainAspectRatio: false,
         plugins: {
           ...themePlugins,
-          legend: { ...themePlugins.legend, display: this.showLegend },
+          legend: { ...themePlugins.legend, display: props.showLegend },
         },
         scales: {
           ...themeScales,
           x: {
             ...themeScales.x,
-            stacked: this.stacked,
-            title: { display: !!this.xLabel, text: this.xLabel },
+            stacked: props.stacked,
+            title: { display: !!props.xLabel, text: props.xLabel },
           },
           y: {
             ...themeScales.y,
-            stacked: this.stacked,
-            title: { display: !!this.yLabel, text: this.yLabel },
+            stacked: props.stacked,
+            title: { display: !!props.yLabel, text: props.yLabel },
           },
         },
       },
-    });
-  }
-
-  protected override render() {
-    if (this.fetcher.state === "loading")
-      return html`<div class="state-message"><slot name="loading">Loading…</slot></div>`;
-    if (this.fetcher.state === "error")
-      return html`<div class="state-message"><slot name="error">Failed to load data.</slot></div>`;
-    const resolved = this.data ?? this.fetcher.data;
-    if (resolved && resolved.length === 0)
-      return html`<div class="state-message"><slot name="empty">No data.</slot></div>`;
-    return html`<canvas ${ref(this.chartCtrl.canvasRef)}></canvas>`;
-  }
-}
+    };
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-line-area": PqLineArea;
+    "pq-line-area": InstanceType<typeof PqLineArea>;
   }
 }

--- a/packages/charts/src/generic/ranked-bar.visual.ts
+++ b/packages/charts/src/generic/ranked-bar.visual.ts
@@ -1,11 +1,7 @@
-import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { ref } from "lit/directives/ref.js";
-import { ChartController } from "../controllers/chart.controller";
-import { DataFetchController } from "../controllers/data-fetch.controller";
-import { ThemeController } from "../controllers/theme.controller";
+import type { ChartConfiguration } from "chart.js";
 import { sliceItems, sortItems } from "../mappers/ranked-bar.mapper";
-import type { RankedBarItem, SortDirection, ThemePreset } from "../types";
+import type { RankedBarItem, SortDirection } from "../types";
+import { defineGenericChart } from "./define-generic-chart";
 
 /**
  * Ranked bar chart web component backed by Chart.js.
@@ -35,61 +31,38 @@ import type { RankedBarItem, SortDirection, ThemePreset } from "../types";
  * ></pq-ranked-bar>
  * ```
  */
-@customElement("pq-ranked-bar")
-export class PqRankedBar extends LitElement {
-  static override styles = css`
-    :host { display: block; position: relative; width: 100%; height: 100%; }
-    canvas { width: 100% !important; height: 100% !important; }
-    .state-message {
-      display: flex; align-items: center; justify-content: center;
-      min-height: 200px;
-      color: var(--pq-chart-text, #e0e0e0);
-      font-family: var(--pq-chart-font-family, system-ui, sans-serif);
-    }
-  `;
+export const PqRankedBar = defineGenericChart<
+  RankedBarItem,
+  { limit: number; horizontal: boolean; sort: SortDirection }
+>({
+  tag: "pq-ranked-bar",
+  properties: {
+    limit: { type: Number },
+    horizontal: { type: Boolean },
+    sort: {},
+  },
+  defaults: { limit: 0, horizontal: true, sort: "desc" },
+  buildConfig: ({ resolved, themeCtrl, props }): ChartConfiguration => {
+    const sorted = sortItems(resolved, props.sort);
+    const sliced = sliceItems(sorted, props.limit);
+    const themePlugins = themeCtrl.options.plugins;
+    const themeScales = themeCtrl.options.scales;
 
-  private fetcher = new DataFetchController<RankedBarItem>(this);
-  private chartCtrl = new ChartController(this);
-  private themeCtrl = new ThemeController(this);
-
-  @property({ type: Array }) data?: RankedBarItem[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property({ type: Number }) limit = 0;
-  @property({ type: Boolean }) horizontal = true;
-  @property() sort: SortDirection = "desc";
-  @property({ type: Boolean, attribute: "animated" }) animated = true;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("theme")) this.themeCtrl.update(this.theme);
-    if (changed.has("animated")) this.chartCtrl.animate = this.animated;
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-    this.renderChart();
-  }
-
-  private renderChart(): void {
-    const resolved = this.data ?? this.fetcher.data;
-    if (!resolved?.length) return;
-    const sorted = sortItems(resolved, this.sort);
-    const sliced = sliceItems(sorted, this.limit);
-    const themePlugins = this.themeCtrl.options.plugins;
-    const themeScales = this.themeCtrl.options.scales;
-    this.chartCtrl.update({
+    return {
       type: "bar",
       data: {
         labels: sliced.map((d) => d.label),
         datasets: [
           {
             data: sliced.map((d) => d.value),
-            backgroundColor: this.themeCtrl.colors[0],
-            borderColor: this.themeCtrl.colors[0],
+            backgroundColor: themeCtrl.colors[0],
+            borderColor: themeCtrl.colors[0],
             borderWidth: 1,
           },
         ],
       },
       options: {
-        indexAxis: this.horizontal ? "y" : "x",
+        indexAxis: props.horizontal ? "y" : "x",
         responsive: true,
         maintainAspectRatio: false,
         plugins: {
@@ -98,23 +71,12 @@ export class PqRankedBar extends LitElement {
         },
         scales: themeScales,
       },
-    });
-  }
-
-  protected override render() {
-    if (this.fetcher.state === "loading")
-      return html`<div class="state-message"><slot name="loading">Loading…</slot></div>`;
-    if (this.fetcher.state === "error")
-      return html`<div class="state-message"><slot name="error">Failed to load data.</slot></div>`;
-    const resolved = this.data ?? this.fetcher.data;
-    if (resolved && resolved.length === 0)
-      return html`<div class="state-message"><slot name="empty">No data.</slot></div>`;
-    return html`<canvas ${ref(this.chartCtrl.canvasRef)}></canvas>`;
-  }
-}
+    };
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-ranked-bar": PqRankedBar;
+    "pq-ranked-bar": InstanceType<typeof PqRankedBar>;
   }
 }

--- a/packages/charts/src/generic/stacked-bar.visual.ts
+++ b/packages/charts/src/generic/stacked-bar.visual.ts
@@ -1,11 +1,7 @@
-import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { ref } from "lit/directives/ref.js";
-import { ChartController } from "../controllers/chart.controller";
-import { DataFetchController } from "../controllers/data-fetch.controller";
-import { ThemeController } from "../controllers/theme.controller";
+import type { ChartConfiguration } from "chart.js";
 import { buildStackedDatasets } from "../mappers/stacked-bar.mapper";
-import type { StackedBarItem, ThemePreset } from "../types";
+import type { StackedBarItem } from "../types";
+import { defineGenericChart } from "./define-generic-chart";
 
 /**
  * Stacked bar chart web component backed by Chart.js.
@@ -32,68 +28,42 @@ import type { StackedBarItem, ThemePreset } from "../types";
  * ></pq-stacked-bar>
  * ```
  */
-@customElement("pq-stacked-bar")
-export class PqStackedBar extends LitElement {
-  static override styles = css`
-    :host { display: block; position: relative; width: 100%; height: 100%; }
-    canvas { width: 100% !important; height: 100% !important; }
-    .state-message {
-      display: flex; align-items: center; justify-content: center;
-      min-height: 200px;
-      color: var(--pq-chart-text, #e0e0e0);
-      font-family: var(--pq-chart-font-family, system-ui, sans-serif);
-    }
-  `;
-
-  private fetcher = new DataFetchController<StackedBarItem>(this);
-  private chartCtrl = new ChartController(this);
-  private themeCtrl = new ThemeController(this);
-
-  @property({ type: Array }) data?: StackedBarItem[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property({ type: Number }) limit = 0;
-  @property({ type: Boolean }) horizontal = false;
-  @property({ type: Boolean, attribute: "show-legend" }) showLegend = true;
-  @property({ type: Boolean, attribute: "animated" }) animated = true;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("theme")) this.themeCtrl.update(this.theme);
-    if (changed.has("animated")) this.chartCtrl.animate = this.animated;
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-    this.renderChart();
-  }
-
-  private renderChart(): void {
-    const resolved = this.data ?? this.fetcher.data;
-    if (!resolved?.length) return;
-
-    const sliced = this.limit > 0 ? resolved.slice(0, this.limit) : resolved;
+export const PqStackedBar = defineGenericChart<
+  StackedBarItem,
+  { limit: number; horizontal: boolean; showLegend: boolean }
+>({
+  tag: "pq-stacked-bar",
+  properties: {
+    limit: { type: Number },
+    horizontal: { type: Boolean },
+    showLegend: { type: Boolean, attribute: "show-legend" },
+  },
+  defaults: { limit: 0, horizontal: false, showLegend: true },
+  buildConfig: ({ resolved, themeCtrl, props }): ChartConfiguration => {
+    const sliced = props.limit > 0 ? resolved.slice(0, props.limit) : resolved;
     const { labels, datasets } = buildStackedDatasets(sliced);
+    const themePlugins = themeCtrl.options.plugins;
+    const themeScales = themeCtrl.options.scales;
 
-    const themePlugins = this.themeCtrl.options.plugins;
-    const themeScales = this.themeCtrl.options.scales;
-
-    this.chartCtrl.update({
+    return {
       type: "bar",
       data: {
         labels,
         datasets: datasets.map((ds, i) => ({
           label: ds.label,
           data: ds.data,
-          backgroundColor: this.themeCtrl.colors[i % this.themeCtrl.colors.length],
-          borderColor: this.themeCtrl.colors[i % this.themeCtrl.colors.length],
+          backgroundColor: themeCtrl.colors[i % themeCtrl.colors.length],
+          borderColor: themeCtrl.colors[i % themeCtrl.colors.length],
           borderWidth: 1,
         })),
       },
       options: {
-        indexAxis: this.horizontal ? "y" : "x",
+        indexAxis: props.horizontal ? "y" : "x",
         responsive: true,
         maintainAspectRatio: false,
         plugins: {
           ...themePlugins,
-          legend: { ...themePlugins.legend, display: this.showLegend },
+          legend: { ...themePlugins.legend, display: props.showLegend },
         },
         scales: {
           ...themeScales,
@@ -101,23 +71,12 @@ export class PqStackedBar extends LitElement {
           y: { ...themeScales.y, stacked: true },
         },
       },
-    });
-  }
-
-  protected override render() {
-    if (this.fetcher.state === "loading")
-      return html`<div class="state-message"><slot name="loading">Loading…</slot></div>`;
-    if (this.fetcher.state === "error")
-      return html`<div class="state-message"><slot name="error">Failed to load data.</slot></div>`;
-    const resolved = this.data ?? this.fetcher.data;
-    if (resolved && resolved.length === 0)
-      return html`<div class="state-message"><slot name="empty">No data.</slot></div>`;
-    return html`<canvas ${ref(this.chartCtrl.canvasRef)}></canvas>`;
-  }
-}
+    };
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-stacked-bar": PqStackedBar;
+    "pq-stacked-bar": InstanceType<typeof PqStackedBar>;
   }
 }

--- a/packages/charts/src/generic/treemap.visual.ts
+++ b/packages/charts/src/generic/treemap.visual.ts
@@ -77,7 +77,7 @@ export const PqTreemap = defineGenericChart<
               color: themeCtrl.theme.text,
               font: {
                 family: themeCtrl.theme.fontFamily,
-                size: parseInt(themeCtrl.theme.fontSize, 10),
+                size: Number.parseInt(themeCtrl.theme.fontSize, 10),
               },
               formatter: (ctx: ScriptableContext<"treemap">) =>
                 (ctx.raw as TreemapDataPoint | undefined)?.g ?? "",

--- a/packages/charts/src/generic/treemap.visual.ts
+++ b/packages/charts/src/generic/treemap.visual.ts
@@ -1,12 +1,7 @@
-import type { ScriptableContext, TooltipItem } from "chart.js";
+import type { ChartConfiguration, ScriptableContext, TooltipItem } from "chart.js";
 import type { TreemapDataPoint } from "chartjs-chart-treemap";
-import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { ref } from "lit/directives/ref.js";
-import { ChartController } from "../controllers/chart.controller";
-import { DataFetchController } from "../controllers/data-fetch.controller";
-import { ThemeController } from "../controllers/theme.controller";
-import type { ThemePreset, TreemapItem } from "../types";
+import type { TreemapItem } from "../types";
+import { defineGenericChart } from "./define-generic-chart";
 
 /**
  * Treemap chart web component backed by Chart.js + chartjs-chart-treemap.
@@ -32,44 +27,19 @@ import type { ThemePreset, TreemapItem } from "../types";
  * ></pq-treemap>
  * ```
  */
-@customElement("pq-treemap")
-export class PqTreemap extends LitElement {
-  static override styles = css`
-    :host { display: block; position: relative; width: 100%; height: 100%; }
-    canvas { width: 100% !important; height: 100% !important; }
-    .state-message {
-      display: flex; align-items: center; justify-content: center;
-      min-height: 200px;
-      color: var(--pq-chart-text, #e0e0e0);
-      font-family: var(--pq-chart-font-family, system-ui, sans-serif);
-    }
-  `;
-
-  private fetcher = new DataFetchController<TreemapItem>(this);
-  private chartCtrl = new ChartController(this);
-  private themeCtrl = new ThemeController(this);
-
-  @property({ type: Array }) data?: TreemapItem[];
-  @property() src?: string;
-  @property() theme?: ThemePreset;
-  @property({ type: Boolean, attribute: "show-labels" }) showLabels = false;
-  @property({ attribute: "color-field" }) colorField = "";
-  @property({ type: Boolean, attribute: "animated" }) animated = true;
-
-  protected override async updated(changed: Map<string, unknown>): Promise<void> {
-    if (changed.has("theme")) this.themeCtrl.update(this.theme);
-    if (changed.has("animated")) this.chartCtrl.animate = this.animated;
-    if (changed.has("src") || changed.has("data"))
-      await this.fetcher.fetch(this.src ?? "", !!this.data);
-    this.renderChart();
-  }
-
-  private renderChart(): void {
-    const resolved = this.data ?? this.fetcher.data;
-    if (!resolved?.length) return;
-
-    const themePlugins = this.themeCtrl.options.plugins;
-    const colors = this.themeCtrl.colors;
+export const PqTreemap = defineGenericChart<
+  TreemapItem,
+  { showLabels: boolean; colorField: string }
+>({
+  tag: "pq-treemap",
+  properties: {
+    showLabels: { type: Boolean, attribute: "show-labels" },
+    colorField: { attribute: "color-field" },
+  },
+  defaults: { showLabels: false, colorField: "" },
+  buildConfig: ({ resolved, themeCtrl, props }): ChartConfiguration => {
+    const themePlugins = themeCtrl.options.plugins;
+    const colors = themeCtrl.colors;
 
     // Build flat tree objects for chartjs-chart-treemap
     // Each item gets a label (last path segment) and value
@@ -80,7 +50,7 @@ export class PqTreemap extends LitElement {
       ...(item.color !== undefined ? { colorIndex: item.color } : {}),
     }));
 
-    this.chartCtrl.update({
+    return {
       type: "treemap",
       data: {
         datasets: [
@@ -99,15 +69,15 @@ export class PqTreemap extends LitElement {
                   : ctx.dataIndex % colors.length;
               return colors[idx] ?? colors[0];
             },
-            borderColor: this.themeCtrl.theme.border,
+            borderColor: themeCtrl.theme.border,
             borderWidth: 1,
             spacing: 2,
             labels: {
-              display: this.showLabels,
-              color: this.themeCtrl.theme.text,
+              display: props.showLabels,
+              color: themeCtrl.theme.text,
               font: {
-                family: this.themeCtrl.theme.fontFamily,
-                size: parseInt(this.themeCtrl.theme.fontSize, 10),
+                family: themeCtrl.theme.fontFamily,
+                size: parseInt(themeCtrl.theme.fontSize, 10),
               },
               formatter: (ctx: ScriptableContext<"treemap">) =>
                 (ctx.raw as TreemapDataPoint | undefined)?.g ?? "",
@@ -132,23 +102,12 @@ export class PqTreemap extends LitElement {
           },
         },
       },
-    });
-  }
-
-  protected override render() {
-    if (this.fetcher.state === "loading")
-      return html`<div class="state-message"><slot name="loading">Loading…</slot></div>`;
-    if (this.fetcher.state === "error")
-      return html`<div class="state-message"><slot name="error">Failed to load data.</slot></div>`;
-    const resolved = this.data ?? this.fetcher.data;
-    if (resolved && resolved.length === 0)
-      return html`<div class="state-message"><slot name="empty">No data.</slot></div>`;
-    return html`<canvas ${ref(this.chartCtrl.canvasRef)}></canvas>`;
-  }
-}
+    };
+  },
+});
 
 declare global {
   interface HTMLElementTagNameMap {
-    "pq-treemap": PqTreemap;
+    "pq-treemap": InstanceType<typeof PqTreemap>;
   }
 }

--- a/packages/charts/tests/domain/define-domain-chart.test.ts
+++ b/packages/charts/tests/domain/define-domain-chart.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { html } from "lit";
+import { DataFetchController } from "../../src/controllers/data-fetch.controller";
+import { defineDomainChart } from "../../src/domain/define-domain-chart";
+
+type RenderEl = {
+  render(): unknown;
+};
+
+// Register shared test charts at module level to avoid double-registration
+
+const RegistrationChart = defineDomainChart<{ id: string }>({
+  tag: "pq-test-domain-registration",
+  defaultVariant: "bar",
+  variants: {
+    bar: (data, _theme, _limit) => html`<span>${data.length}</span>`,
+  },
+});
+
+const DefaultVariantChart = defineDomainChart<{ id: string }>({
+  tag: "pq-test-domain-default-variant",
+  defaultVariant: "treemap",
+  variants: {
+    treemap: (_data, _theme) => html`<div>treemap</div>`,
+  },
+});
+
+const LimitChart = defineDomainChart<{ id: string }>({
+  tag: "pq-test-domain-limit-default",
+  defaultVariant: "bar",
+  variants: {
+    bar: (_data, _theme, _limit) => html`<span>bar</span>`,
+  },
+  // No limit specified — should default to 20
+});
+
+const LimitCustomChart = defineDomainChart<{ id: string }>({
+  tag: "pq-test-domain-limit-custom",
+  defaultVariant: "bar",
+  variants: {
+    bar: (_data, _theme, _limit) => html`<span>bar</span>`,
+  },
+  limit: 10,
+});
+
+// Lifecycle test chart
+const LifecycleDomainChart = defineDomainChart<{ value: number }>({
+  tag: "pq-test-domain-lifecycle",
+  defaultVariant: "bar",
+  variants: {
+    bar: (data, _theme, _limit) => html`<span>${data.length}</span>`,
+  },
+});
+
+// ResolvedData test chart
+const ResolvedDataChart = defineDomainChart<{ value: number }>({
+  tag: "pq-test-domain-resolved",
+  defaultVariant: "bar",
+  variants: {
+    bar: (data, _theme, _limit) => html`<span>${data.length}</span>`,
+  },
+});
+
+// Render test chart — captures what renderer was called
+let lastRendererCalled: string | undefined;
+let lastDataReceived: unknown[] | undefined;
+let lastThemeReceived: unknown;
+let lastLimitReceived: number | undefined;
+
+const RenderVariantChart = defineDomainChart<{ value: number }>({
+  tag: "pq-test-domain-render",
+  defaultVariant: "bar",
+  variants: {
+    bar: (data, theme, limit) => {
+      lastRendererCalled = "bar";
+      lastDataReceived = data;
+      lastThemeReceived = theme;
+      lastLimitReceived = limit;
+      return html`<pq-bar-test></pq-bar-test>`;
+    },
+    treemap: (data, theme, limit) => {
+      lastRendererCalled = "treemap";
+      lastDataReceived = data;
+      lastThemeReceived = theme;
+      lastLimitReceived = limit;
+      return html`<pq-treemap-test></pq-treemap-test>`;
+    },
+  },
+});
+
+const UnknownVariantChart = defineDomainChart<{ value: number }>({
+  tag: "pq-test-domain-unknown-variant",
+  defaultVariant: "bar",
+  variants: {
+    bar: (_data) => html`<span>bar</span>`,
+  },
+});
+
+describe("defineDomainChart", () => {
+  describe("2-A: Factory registration and defaults", () => {
+    it("2.1 registers the custom element with the provided tag", () => {
+      expect(customElements.get("pq-test-domain-registration")).toBeDefined();
+    });
+
+    it("2.3 default variant is applied — instantiate component, verify variant equals defaultVariant", () => {
+      const el = new DefaultVariantChart() as InstanceType<typeof DefaultVariantChart> & {
+        variant: string;
+      };
+      expect(el.variant).toBe("treemap");
+    });
+
+    it("2.5 limit defaults to config.limit ?? 20 when not specified in config", () => {
+      const el = new LimitChart() as InstanceType<typeof LimitChart> & { limit: number };
+      expect(el.limit).toBe(20);
+    });
+
+    it("2.5b limit uses config.limit when specified", () => {
+      const el = new LimitCustomChart() as InstanceType<typeof LimitCustomChart> & {
+        limit: number;
+      };
+      expect(el.limit).toBe(10);
+    });
+
+    it("2.3b static properties includes all five base properties", () => {
+      const props = (
+        RegistrationChart as typeof RegistrationChart & { properties: Record<string, unknown> }
+      ).properties;
+      expect(props).toHaveProperty("data");
+      expect(props).toHaveProperty("src");
+      expect(props).toHaveProperty("theme");
+      expect(props).toHaveProperty("variant");
+      expect(props).toHaveProperty("limit");
+    });
+  });
+
+  describe("2-B: Lifecycle delegation", () => {
+    afterEach(() => {
+      // Spies restored per test
+    });
+
+    it("2.10 updated() calls fetcher.fetch() when src changes", async () => {
+      const fetchSpy = spyOn(DataFetchController.prototype, "fetch").mockResolvedValue(undefined);
+      const el = new LifecycleDomainChart() as unknown as {
+        updated(changed: Map<PropertyKey, unknown>): Promise<void>;
+      };
+      const changed = new Map<PropertyKey, unknown>([["src", undefined]]);
+      await el.updated(changed);
+      expect(fetchSpy).toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+
+    it("2.11 updated() calls fetcher.fetch() when data changes", async () => {
+      const fetchSpy = spyOn(DataFetchController.prototype, "fetch").mockResolvedValue(undefined);
+      const el = new LifecycleDomainChart() as unknown as {
+        updated(changed: Map<PropertyKey, unknown>): Promise<void>;
+      };
+      const changed = new Map<PropertyKey, unknown>([["data", undefined]]);
+      await el.updated(changed);
+      expect(fetchSpy).toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+  });
+
+  describe("2-B: resolvedData getter", () => {
+    it("2.13 resolvedData returns this.data when data prop is set", () => {
+      const el = new ResolvedDataChart() as InstanceType<typeof ResolvedDataChart> & {
+        data?: Array<{ value: number }>;
+        resolvedData: Array<{ value: number }>;
+      };
+      const items = [{ value: 1 }, { value: 2 }];
+      el.data = items;
+      // Access via prototype cast since it's a private getter
+      const resolved = (el as unknown as { resolvedData: Array<{ value: number }> }).resolvedData;
+      expect(resolved).toEqual(items);
+    });
+
+    it("2.14 resolvedData returns fetcher.data when data prop is not set", () => {
+      const el = new ResolvedDataChart() as InstanceType<typeof ResolvedDataChart> & {
+        data?: Array<{ value: number }>;
+      };
+      const fetcher = (el as unknown as { fetcher: DataFetchController<{ value: number }> })
+        .fetcher;
+      fetcher.data = [{ value: 99 }];
+      const resolved = (el as unknown as { resolvedData: Array<{ value: number }> }).resolvedData;
+      expect(resolved).toEqual([{ value: 99 }]);
+    });
+
+    it("2.15 resolvedData returns [] when neither data nor fetcher.data is set", () => {
+      const el = new ResolvedDataChart();
+      const resolved = (el as unknown as { resolvedData: Array<{ value: number }> }).resolvedData;
+      expect(resolved).toEqual([]);
+    });
+  });
+
+  describe("2-B: render delegation", () => {
+    it("2.17 render() calls the variant renderer with (resolvedData, theme, limit)", () => {
+      lastRendererCalled = undefined;
+      lastDataReceived = undefined;
+      lastThemeReceived = undefined;
+      lastLimitReceived = undefined;
+
+      const el = new RenderVariantChart() as InstanceType<typeof RenderVariantChart> & {
+        data?: Array<{ value: number }>;
+        theme?: string;
+        limit: number;
+        variant: string;
+      };
+      el.data = [{ value: 1 }];
+      el.theme = "dark" as never;
+      el.limit = 5;
+      el.variant = "bar";
+
+      const renderEl = el as unknown as RenderEl;
+      renderEl.render();
+
+      expect(lastRendererCalled).toBe("bar");
+      expect(lastDataReceived).toEqual([{ value: 1 }]);
+      expect(lastThemeReceived).toBe("dark");
+      expect(lastLimitReceived).toBe(5);
+    });
+
+    it("2.18 render() returns undefined for an unknown variant", () => {
+      const el = new UnknownVariantChart() as InstanceType<typeof UnknownVariantChart> & {
+        variant: string;
+      };
+      el.variant = "unknown-variant-xyz";
+      const result = (el as unknown as RenderEl).render();
+      expect(result).toBeUndefined();
+    });
+
+    it("2.20 switching variant at runtime calls the new renderer", () => {
+      lastRendererCalled = undefined;
+
+      const el = new RenderVariantChart() as InstanceType<typeof RenderVariantChart> & {
+        data?: Array<{ value: number }>;
+        variant: string;
+      };
+      el.data = [{ value: 1 }];
+      el.variant = "treemap";
+
+      (el as unknown as RenderEl).render();
+
+      expect(lastRendererCalled).toBe("treemap");
+    });
+  });
+});

--- a/packages/charts/tests/domain/define-domain-chart.test.ts
+++ b/packages/charts/tests/domain/define-domain-chart.test.ts
@@ -107,7 +107,7 @@ const ExtraPropsChart = defineDomainChart<{ value: number }, { bins: number }>({
   properties: { bins: { type: Number } },
   defaults: { bins: 10 },
   variants: {
-    histogram: (data, theme, limit, extra) => {
+    histogram: (data, _theme, _limit, extra) => {
       lastExtraReceived = extra as Record<string, unknown>;
       return html`<span>${data.length}-${(extra as { bins: number }).bins}</span>`;
     },
@@ -130,6 +130,20 @@ const ExtraEntityChart = defineDomainChart<{ value: number }, { entity: string }
 });
 
 describe("defineDomainChart", () => {
+  describe("F: Double-registration guard", () => {
+    it("F.1 calling defineDomainChart twice with the same tag does not throw", () => {
+      expect(() => {
+        defineDomainChart<{ id: string }>({
+          tag: "pq-test-domain-registration", // already registered at module level
+          defaultVariant: "bar",
+          variants: {
+            bar: (_data) => html`<span>bar</span>`,
+          },
+        });
+      }).not.toThrow();
+    });
+  });
+
   describe("2-A: Factory registration and defaults", () => {
     it("2.1 registers the custom element with the provided tag", () => {
       expect(customElements.get("pq-test-domain-registration")).toBeDefined();

--- a/packages/charts/tests/domain/define-domain-chart.test.ts
+++ b/packages/charts/tests/domain/define-domain-chart.test.ts
@@ -96,6 +96,39 @@ const UnknownVariantChart = defineDomainChart<{ value: number }>({
   },
 });
 
+// ─── Task A: extra props support ─────────────────────────────────────────────
+
+// Chart with extra `bins` property (mimics age-chart)
+let lastExtraReceived: Record<string, unknown> | undefined;
+
+const ExtraPropsChart = defineDomainChart<{ value: number }, { bins: number }>({
+  tag: "pq-test-domain-extra-props",
+  defaultVariant: "histogram",
+  properties: { bins: { type: Number } },
+  defaults: { bins: 10 },
+  variants: {
+    histogram: (data, theme, limit, extra) => {
+      lastExtraReceived = extra as Record<string, unknown>;
+      return html`<span>${data.length}-${(extra as { bins: number }).bins}</span>`;
+    },
+  },
+});
+
+// Chart with extra `entity` property (mimics effort-chart and ownership-chart)
+const ExtraEntityChart = defineDomainChart<{ value: number }, { entity: string }>({
+  tag: "pq-test-domain-extra-entity",
+  defaultVariant: "stacked",
+  properties: { entity: {} },
+  defaults: { entity: "" },
+  variants: {
+    stacked: (_data, _theme, _limit, _extra) => html`<span>stacked</span>`,
+    doughnut: (data, _theme, _limit, extra) => {
+      lastExtraReceived = extra as Record<string, unknown>;
+      return html`<span>${data.length}-${(extra as { entity: string }).entity}</span>`;
+    },
+  },
+});
+
 describe("defineDomainChart", () => {
   describe("2-A: Factory registration and defaults", () => {
     it("2.1 registers the custom element with the provided tag", () => {
@@ -189,6 +222,53 @@ describe("defineDomainChart", () => {
       const el = new ResolvedDataChart();
       const resolved = (el as unknown as { resolvedData: Array<{ value: number }> }).resolvedData;
       expect(resolved).toEqual([]);
+    });
+  });
+
+  describe("A: Extra props support", () => {
+    it("A.1 extra prop has its default value when instantiated", () => {
+      const el = new ExtraPropsChart() as InstanceType<typeof ExtraPropsChart> & { bins: number };
+      expect(el.bins).toBe(10);
+    });
+
+    it("A.2 static properties includes extra prop key from config.properties", () => {
+      const props = (
+        ExtraPropsChart as typeof ExtraPropsChart & { properties: Record<string, unknown> }
+      ).properties;
+      expect(props).toHaveProperty("bins");
+    });
+
+    it("A.3 render() passes extra props as 4th argument to variant renderer", () => {
+      lastExtraReceived = undefined;
+      const el = new ExtraPropsChart() as InstanceType<typeof ExtraPropsChart> & {
+        data?: Array<{ value: number }>;
+        bins: number;
+      };
+      el.data = [{ value: 1 }];
+      el.bins = 7;
+      (el as unknown as RenderEl).render();
+      expect(lastExtraReceived).toEqual({ bins: 7 });
+    });
+
+    it("A.4 extra string prop defaults to empty string when instantiated", () => {
+      const el = new ExtraEntityChart() as InstanceType<typeof ExtraEntityChart> & {
+        entity: string;
+      };
+      expect(el.entity).toBe("");
+    });
+
+    it("A.5 extra entity prop is passed to variant renderer as 4th argument", () => {
+      lastExtraReceived = undefined;
+      const el = new ExtraEntityChart() as InstanceType<typeof ExtraEntityChart> & {
+        data?: Array<{ value: number }>;
+        entity: string;
+        variant: string;
+      };
+      el.data = [{ value: 42 }];
+      el.entity = "src/main.ts";
+      el.variant = "doughnut";
+      (el as unknown as RenderEl).render();
+      expect(lastExtraReceived).toEqual({ entity: "src/main.ts" });
     });
   });
 

--- a/packages/charts/tests/generic/define-generic-chart.test.ts
+++ b/packages/charts/tests/generic/define-generic-chart.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { defineGenericChart } from "../../src/generic/define-generic-chart";
+
+// Register shared test charts at module level to avoid double-registration
+const RegistrationChart = defineGenericChart({
+  tag: "pq-test-factory-registration",
+  properties: {},
+  defaults: {},
+  buildConfig: () => ({ type: "bar", data: { datasets: [] }, options: {} }),
+});
+
+const PropsChart = defineGenericChart<{ value: number }, { label: string }>({
+  tag: "pq-test-base-props",
+  properties: { label: {} },
+  defaults: { label: "" },
+  buildConfig: () => ({ type: "bar", data: { datasets: [] }, options: {} }),
+});
+
+const DefaultsChart = defineGenericChart<{ value: number }, { label: string }>({
+  tag: "pq-test-defaults",
+  properties: { label: {} },
+  defaults: { label: "hello" },
+  buildConfig: () => ({ type: "bar", data: { datasets: [] }, options: {} }),
+});
+
+describe("defineGenericChart", () => {
+  describe("1-A: Factory registration and static properties", () => {
+    it("1.1 registers the custom element with the provided tag", () => {
+      expect(customElements.get("pq-test-factory-registration")).toBeDefined();
+    });
+
+    it("1.3 static properties includes all four base properties", () => {
+      const props = (
+        RegistrationChart as typeof RegistrationChart & { properties: Record<string, unknown> }
+      ).properties;
+      expect(props).toHaveProperty("data");
+      expect(props).toHaveProperty("src");
+      expect(props).toHaveProperty("theme");
+      expect(props).toHaveProperty("animated");
+    });
+
+    it("1.5 static properties includes consumer-declared properties with correct descriptors", () => {
+      const props = (PropsChart as typeof PropsChart & { properties: Record<string, unknown> })
+        .properties;
+      expect(props).toHaveProperty("label");
+    });
+
+    it("1.7 default values are applied on construction", () => {
+      const el = new DefaultsChart() as InstanceType<typeof DefaultsChart> & { label: string };
+      expect(el.label).toBe("hello");
+    });
+  });
+});

--- a/packages/charts/tests/generic/define-generic-chart.test.ts
+++ b/packages/charts/tests/generic/define-generic-chart.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { ChartController } from "../../src/controllers/chart.controller";
+import { DataFetchController } from "../../src/controllers/data-fetch.controller";
+import { ThemeController } from "../../src/controllers/theme.controller";
 import { defineGenericChart } from "../../src/generic/define-generic-chart";
+
+// Helper to invoke the protected updated() method directly
+type GenericEl = {
+  updated(changed: Map<PropertyKey, unknown>): Promise<void>;
+};
 
 // Register shared test charts at module level to avoid double-registration
 const RegistrationChart = defineGenericChart({
@@ -7,6 +15,18 @@ const RegistrationChart = defineGenericChart({
   properties: {},
   defaults: {},
   buildConfig: () => ({ type: "bar", data: { datasets: [] }, options: {} }),
+});
+
+// Lifecycle test chart — registered ONCE at module level
+const LifecycleChart = defineGenericChart<{ value: number }, { label: string }>({
+  tag: "pq-test-chart-lifecycle",
+  properties: { label: {} },
+  defaults: { label: "" },
+  buildConfig: ({ resolved }) => ({
+    type: "bar",
+    data: { datasets: [{ data: resolved.map((d) => d.value) }] },
+    options: {},
+  }),
 });
 
 const PropsChart = defineGenericChart<{ value: number }, { label: string }>({
@@ -48,6 +68,59 @@ describe("defineGenericChart", () => {
     it("1.7 default values are applied on construction", () => {
       const el = new DefaultsChart() as InstanceType<typeof DefaultsChart> & { label: string };
       expect(el.label).toBe("hello");
+    });
+  });
+
+  describe("1-B: Lifecycle delegation", () => {
+    afterEach(() => {
+      // Spies are restored per-test
+    });
+
+    it("1.12 updated() calls themeCtrl.update() when theme changes", async () => {
+      const updateSpy = spyOn(ThemeController.prototype, "update");
+      const el = new LifecycleChart() as unknown as GenericEl;
+      const changed = new Map<PropertyKey, unknown>([["theme", undefined]]);
+      await el.updated(changed);
+      expect(updateSpy).toHaveBeenCalled();
+      updateSpy.mockRestore();
+    });
+
+    it("1.13 updated() sets chartCtrl.animate when animated changes", async () => {
+      // Spy on the update method since animate setter isn't spyable in bun
+      // We verify the side-effect: chartCtrl.update is called after animate is set via renderChart
+      // For this test, set data so renderChart runs and calls chartCtrl.update
+      const updateSpy = spyOn(ChartController.prototype, "update");
+      const fetchSpy = spyOn(DataFetchController.prototype, "fetch").mockResolvedValue(undefined);
+      const el = new LifecycleChart() as unknown as GenericEl & {
+        animated: boolean;
+        data?: Array<{ value: number }>;
+      };
+      el.data = [{ value: 1 }];
+      el.animated = false;
+      const changed = new Map<PropertyKey, unknown>([["animated", true]]);
+      await el.updated(changed);
+      // chartCtrl.update is called with animation being false (set via animate setter)
+      expect(updateSpy).toHaveBeenCalled();
+      updateSpy.mockRestore();
+      fetchSpy.mockRestore();
+    });
+
+    it("1.14 updated() calls fetcher.fetch() when src changes", async () => {
+      const fetchSpy = spyOn(DataFetchController.prototype, "fetch").mockResolvedValue(undefined);
+      const el = new LifecycleChart() as unknown as GenericEl;
+      const changed = new Map<PropertyKey, unknown>([["src", undefined]]);
+      await el.updated(changed);
+      expect(fetchSpy).toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+
+    it("1.15 updated() calls fetcher.fetch() when data changes", async () => {
+      const fetchSpy = spyOn(DataFetchController.prototype, "fetch").mockResolvedValue(undefined);
+      const el = new LifecycleChart() as unknown as GenericEl;
+      const changed = new Map<PropertyKey, unknown>([["data", undefined]]);
+      await el.updated(changed);
+      expect(fetchSpy).toHaveBeenCalled();
+      fetchSpy.mockRestore();
     });
   });
 });

--- a/packages/charts/tests/generic/define-generic-chart.test.ts
+++ b/packages/charts/tests/generic/define-generic-chart.test.ts
@@ -71,6 +71,19 @@ const RenderTestChart = defineGenericChart<{ value: number }, { label: string }>
 });
 
 describe("defineGenericChart", () => {
+  describe("F: Double-registration guard", () => {
+    it("F.1 calling defineGenericChart twice with the same tag does not throw", () => {
+      expect(() => {
+        defineGenericChart({
+          tag: "pq-test-factory-registration", // already registered at module level
+          properties: {},
+          defaults: {},
+          buildConfig: () => ({ type: "bar", data: { datasets: [] }, options: {} }),
+        });
+      }).not.toThrow();
+    });
+  });
+
   describe("1-A: Factory registration and static properties", () => {
     it("1.1 registers the custom element with the provided tag", () => {
       expect(customElements.get("pq-test-factory-registration")).toBeDefined();

--- a/packages/charts/tests/generic/define-generic-chart.test.ts
+++ b/packages/charts/tests/generic/define-generic-chart.test.ts
@@ -9,6 +9,17 @@ type GenericEl = {
   updated(changed: Map<PropertyKey, unknown>): Promise<void>;
 };
 
+type RenderEl = {
+  render(): unknown;
+};
+
+/** Extract HTML string content from a Lit TemplateResult */
+function templateHtml(result: unknown): string {
+  const r = result as { strings?: string[] };
+  if (!r?.strings) return "";
+  return r.strings.join("");
+}
+
 // Register shared test charts at module level to avoid double-registration
 const RegistrationChart = defineGenericChart({
   tag: "pq-test-factory-registration",
@@ -41,6 +52,22 @@ const DefaultsChart = defineGenericChart<{ value: number }, { label: string }>({
   properties: { label: {} },
   defaults: { label: "hello" },
   buildConfig: () => ({ type: "bar", data: { datasets: [] }, options: {} }),
+});
+
+// Chart for renderChart + render state tests
+let capturedProps: { label: string } | undefined;
+const RenderTestChart = defineGenericChart<{ value: number }, { label: string }>({
+  tag: "pq-test-render-chart",
+  properties: { label: {} },
+  defaults: { label: "" },
+  buildConfig: ({ resolved, props }) => {
+    capturedProps = props;
+    return {
+      type: "bar",
+      data: { datasets: [{ data: resolved.map((d) => d.value) }] },
+      options: {},
+    };
+  },
 });
 
 describe("defineGenericChart", () => {
@@ -121,6 +148,88 @@ describe("defineGenericChart", () => {
       await el.updated(changed);
       expect(fetchSpy).toHaveBeenCalled();
       fetchSpy.mockRestore();
+    });
+  });
+
+  describe("1-C: renderChart + render states", () => {
+    it("1.18 renderChart() is a no-op when resolved data is empty", async () => {
+      const chartUpdateSpy = spyOn(ChartController.prototype, "update");
+      const el = new RenderTestChart() as unknown as GenericEl;
+      // data is undefined, fetcher.data is undefined → resolved is undefined → no-op
+      const changed = new Map<PropertyKey, unknown>([["theme", undefined]]);
+      await el.updated(changed);
+      expect(chartUpdateSpy).not.toHaveBeenCalled();
+      chartUpdateSpy.mockRestore();
+    });
+
+    it("1.19 renderChart() calls chartCtrl.update() with buildConfig result when data is non-empty", async () => {
+      const chartUpdateSpy = spyOn(ChartController.prototype, "update");
+      const fetchSpy = spyOn(DataFetchController.prototype, "fetch").mockResolvedValue(undefined);
+      const el = new RenderTestChart() as unknown as GenericEl & {
+        data?: Array<{ value: number }>;
+      };
+      el.data = [{ value: 42 }];
+      const changed = new Map<PropertyKey, unknown>([["data", undefined]]);
+      await el.updated(changed);
+      expect(chartUpdateSpy).toHaveBeenCalled();
+      chartUpdateSpy.mockRestore();
+      fetchSpy.mockRestore();
+    });
+
+    it("1.20 buildConfig receives correct props snapshot", async () => {
+      const chartUpdateSpy = spyOn(ChartController.prototype, "update");
+      const fetchSpy = spyOn(DataFetchController.prototype, "fetch").mockResolvedValue(undefined);
+      capturedProps = undefined;
+      const el = new RenderTestChart() as unknown as GenericEl & {
+        data?: Array<{ value: number }>;
+        label: string;
+      };
+      el.label = "test-label";
+      el.data = [{ value: 1 }];
+      const changed = new Map<PropertyKey, unknown>([["data", undefined]]);
+      await el.updated(changed);
+      expect(capturedProps?.label).toBe("test-label");
+      chartUpdateSpy.mockRestore();
+      fetchSpy.mockRestore();
+    });
+
+    it("1.22 render() returns loading slot when fetcher.state is loading", () => {
+      const el = new RenderTestChart() as unknown as RenderEl & {
+        fetcher: { state: string };
+      };
+      // Access private fetcher via cast
+      const fetcher = (el as unknown as { fetcher: { state: string } }).fetcher;
+      fetcher.state = "loading";
+      const result = el.render();
+      expect(templateHtml(result)).toContain('name="loading"');
+    });
+
+    it("1.23 render() returns error slot when fetcher.state is error", () => {
+      const el = new RenderTestChart() as unknown as RenderEl & {
+        fetcher: { state: string };
+      };
+      const fetcher = (el as unknown as { fetcher: { state: string } }).fetcher;
+      fetcher.state = "error";
+      const result = el.render();
+      expect(templateHtml(result)).toContain('name="error"');
+    });
+
+    it("1.24 render() returns empty slot when data is empty array", () => {
+      const el = new RenderTestChart() as unknown as RenderEl & {
+        data?: Array<{ value: number }>;
+      };
+      el.data = [];
+      const result = el.render();
+      expect(templateHtml(result)).toContain('name="empty"');
+    });
+
+    it("1.25 render() returns canvas element when data is non-empty", () => {
+      const el = new RenderTestChart() as unknown as RenderEl & {
+        data?: Array<{ value: number }>;
+      };
+      el.data = [{ value: 1 }];
+      const result = el.render();
+      expect(templateHtml(result)).toContain("canvas");
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Two factory functions** replace 25 class-based chart components with pure configuration (~15 lines each instead of ~60-100 lines)
  - `defineGenericChart<T, Props>()` — 8 Chart.js generic components (bubble, doughnut, grouped-bar, histogram, line-area, ranked-bar, stacked-bar, treemap)
  - `defineDomainChart<T, P>()` — 17 domain chart components (all except `summary-cards` which is excluded by design)
- **Zero inheritance** — composition + strategy pattern only. Each component is a config object with variant renderer functions
- **Double-registration guard** in both factories prevents HMR errors in development
- **187 tests passing**, typecheck clean, biome clean

## Motivation

SonarCloud flagged **6.0% code duplication** (268 lines, 28 blocks) in `@prj-conq/charts`. All chart components shared identical boilerplate: `DataFetchController`, base properties, `updated()` lifecycle, `resolvedData` getter. Only the data type, mappers, and variants differed.

## Architecture

### Generic Factory (`defineGenericChart<T, Props>`)
Encapsulates: `ChartController`, `DataFetchController`, `ThemeController`, lifecycle delegation, render states (loading/error/empty/canvas), shared CSS. Consumer provides `buildConfig` strategy that builds Chart.js configuration.

### Domain Factory (`defineDomainChart<T, P>`)
Encapsulates: `DataFetchController`, base properties (`data`, `src`, `theme`, `variant`, `limit`), lifecycle, `resolvedData`. Consumer provides variant renderers that return Lit templates delegating to generic components. Supports extra props via second type parameter `P` (e.g., `bins` for age-chart, `entity` for effort/ownership charts).

## Changes

| Scope | Files | What |
|-------|-------|------|
| Generic factory | `src/generic/define-generic-chart.ts` | NEW — factory + types + double-reg guard |
| Generic tests | `tests/generic/define-generic-chart.test.ts` | NEW — 15 unit tests + 1 guard test |
| Generic components | 8 files in `src/generic/` | Migrated from class → `defineGenericChart()` |
| Generic barrel | `src/generic/index.ts` | Added factory + type exports |
| Domain factory | `src/domain/define-domain-chart.ts` | NEW — factory + types + extra props + guard |
| Domain tests | `tests/domain/define-domain-chart.test.ts` | NEW — 13 unit tests + 5 extra-props + 1 guard |
| Domain components | 17 files in `src/domain/` | Migrated from class → `defineDomainChart()` |
| Domain barrel | `src/domain/index.ts` | Added factory + type exports |

### Untouched (by design)
- `src/generic/enclosure.visual.ts` — D3-based, no `ChartController`, excluded
- `src/domain/summary-cards.visual.ts` — custom rendering, no variants, excluded

## Test Plan

- [x] `bun test` — 187 pass, 0 fail
- [x] `bun run typecheck` — zero errors
- [x] `biome check .` — zero errors
- [x] All 14+3 domain migrations preserve original behavior
- [x] All 8 generic migrations preserve original behavior
- [x] Double-registration guard tested in both factories
- [x] Backward compatibility: existing consumers unaffected (same exports, same element tags)